### PR TITLE
Fix MiMix2S vendor matching pattern

### DIFF
--- a/Xiaomi/MiMix2S/AndroidManifest.xml
+++ b/Xiaomi/MiMix2S/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+Xiaomi/polaris"
+		android:requiredSystemPropertyValue="+Xiaomi/polaris*"
 		android:priority="13"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man7/glob.7.html, we need an asterisk `*` after the value in order to get an inexact matching.