### PR TITLE
Fix ZenFone 5 vendor matching pattern

### DIFF
--- a/Asus/ZenFone5/AndroidManifest.xml
+++ b/Asus/ZenFone5/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+X00QD"
+                android:requiredSystemPropertyValue="+X00QD*"
 		android:priority="14"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
According to http://man7.org/linux/man-pages/man7/glob.7.html, we need an asterisk `*` after the value in order to get an inexact matching.