### PR TITLE
[OP6] Fix Always on Display

### DIFF
--- a/OnePlus/OP6/res/values/config.xml
+++ b/OnePlus/OP6/res/values/config.xml
@@ -64,7 +64,13 @@
     <bool name="config_wifi_background_scan_support">true</bool>
     <bool name="config_wifi_dual_band_support">true</bool>
 
-    <!--<string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
+    <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>-->
+    <bool name="config_displayBlanksAfterDoze">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
+    <bool name="config_enableAutoPowerModes">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_supportDoubleTapWake">true</bool>
+    <bool name="config_skipScreenOnBrightnessRamp">true</bool>
+    <bool name="config_allowAutoBrightnessWhileDozing">true</bool>
 </resources>


### PR DESCRIPTION
From reviewing several sources I believe this commit should resolve the Always on Display issues seen with the OnePlus 6.

A lot of this is based on work for OmniROM at:

https://github.com/omnirom/android_device_oneplus_oneplus6/blob/android-8.1/overlay/frameworks/base/core/res/res/values/config.xml

It's proven very very useful - there may be much more useful info in there so worth a dig through but I believe this addition should at least fix AoD properly.