### PR TITLE
Use build fingerprint check for Mi 8

### DIFF
--- a/Xiaomi/Mi8/AndroidManifest.xml
+++ b/Xiaomi/Mi8/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.product.device"
-                android:requiredSystemPropertyValue="dipper"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+Xiaomi/dipper*"
 		android:priority="12"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Old way doesn't work with Pie vendors.
Move to universal way of determining Mi 8
See this: https://github.com/phhusson/vendor_hardware_overlay/issues/25

Test: make -j64 treble-overlay-xiaomi-mi8; use 9.0 vendor; copy overlay to /system/overlay/; ensure overlay works

Signed-off-by: argraur <argraur@gmail.com>