### PR TITLE
Add resources for Xiaomi Mi 8 SE

### DIFF
--- a/Xiaomi/Mi8SE/res/values/config.xml
+++ b/Xiaomi/Mi8SE/res/values/config.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>3</item>
+        <item>3</item>
+        <item>3</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>12</item>
+        <item>12</item>
+        <item>18</item>
+        <item>18</item>
+        <item>18</item>
+        <item>27</item>
+        <item>27</item>
+        <item>27</item>
+        <item>32</item>
+        <item>32</item>
+        <item>32</item>
+        <item>37</item>
+        <item>46</item>
+        <item>49</item>
+        <item>52</item>
+        <item>53</item>
+        <item>59</item>
+        <item>61</item>
+        <item>64</item>
+        <item>70</item>
+        <item>77</item>
+        <item>85</item>
+        <item>97</item>
+        <item>107</item>
+        <item>120</item>
+        <item>131</item>
+        <item>149</item>
+        <item>175</item>
+        <item>186</item>
+        <item>209</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>10</item>
+        <item>12</item>
+        <item>15</item>
+        <item>18</item>
+        <item>22</item>
+        <item>30</item>
+        <item>40</item>
+        <item>50</item>
+        <item>80</item>
+        <item>110</item>
+        <item>155</item>
+        <item>173</item>
+        <item>300</item>
+        <item>387</item>
+        <item>492</item>
+        <item>533</item>
+        <item>726</item>
+        <item>883</item>
+        <item>1023</item>
+        <item>1222</item>
+        <item>1501</item>
+        <item>1733</item>
+        <item>2034</item>
+        <item>2227</item>
+        <item>2517</item>
+        <item>3042</item>
+        <item>3495</item>
+        <item>3998</item>
+        <item>4472</item>
+    </integer-array>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_supportAudioSourceUnprocessed">true</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    <bool name="config_carrier_volte_available">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_intrusiveNotificationLed">false</bool>
+    <bool name="config_lidControlsSleep">true</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">true</bool>
+    <bool name="config_wifi_disconnect_only_on_initial_ipreachability">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_wifi_dual_sap_mode_enabled">false</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+    <bool name="config_displayBlanksAfterDoze">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_dozeAfterScreenOffByDefault">true</bool>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">200.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">6000</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">1</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessSettingDefault">67</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
+    <integer name="config_bluetooth_idle_cur_ma">1</integer>
+    <integer name="config_bluetooth_operating_voltage_mv">3300</integer>
+    <integer name="config_bluetooth_rx_cur_ma">2</integer>
+    <integer name="config_bluetooth_tx_cur_ma">3</integer>
+    <integer name="config_shutdownBatteryTemperature">600</integer>
+</resources>

--- a/Xiaomi/Mi8SE/res/xml/power_profile.xml
+++ b/Xiaomi/Mi8SE/res/xml/power_profile.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">64.19</item>
+    <item name="screen.full">108.3</item>
+    <item name="bluetooth.active">9.22</item>
+    <item name="bluetooth.on">1.17</item>
+    <item name="wifi.on">0.52</item>
+    <item name="wifi.active">476.28</item>
+    <item name="wifi.scan">21.3</item>
+    <item name="dsp.audio">19.9</item>
+    <item name="dsp.video">40.99</item>
+    <item name="camera.flashlight">160</item>
+    <item name="camera.avg">586</item>
+    <item name="gps.on">132.43</item>
+    <item name="radio.active">134.84</item>
+    <item name="radio.scanning">33.23</item>
+    <array name="radio.on">
+        <value>5.59</value>
+        <value>5.59</value>
+    </array>
+    <item name="modem.controller.idle">0</item>
+    <item name="modem.controller.rx">0</item>
+    <item name="modem.controller.tx">0</item>
+    <item name="modem.controller.voltage">0</item>
+    <array name="cpu.clusters.cores">
+        <value>6</value>
+        <value>2</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>300000</value>
+        <value>576000</value>
+        <value>748000</value>
+        <value>998400</value>
+        <value>1209600</value>
+        <value>1324800</value>
+        <value>1516800</value>
+        <value>1612800</value>
+        <value>1780000</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>31.84</value>
+        <value>35.91</value>
+        <value>37.69</value>
+        <value>45.77</value>
+        <value>53.89</value>
+        <value>59.62</value>
+        <value>66.80</value>
+        <value>72.52</value>
+        <value>80.99</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>300000</value>
+        <value>652800</value>
+        <value>825600</value>
+        <value>979200</value>
+        <value>1132800</value>
+        <value>1363200</value>
+        <value>1536000</value>
+        <value>1747200</value>
+        <value>1843200</value>
+        <value>1996800</value>
+        <value>2054400</value>
+        <value>2169600</value>
+        <value>2208000</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>45.40</value>
+        <value>62.55</value>
+        <value>70.92</value>
+        <value>82.33</value>
+        <value>94.85</value>
+        <value>122.35</value>
+        <value>146.60</value>
+        <value>181.52</value>
+        <value>214.29</value>
+        <value>245.88</value>
+        <value>282.33</value>
+        <value>322.98</value>
+        <value>333.66</value>
+    </array>
+    <item name="cpu.awake">9.6</item>
+    <item name="cpu.idle">6.44</item>
+    <array name="memory.bandwidths">
+        <value>22.7</value>
+    </array>
+    <item name="battery.capacity">3120</item>
+    <item name="wifi.controller.idle">0</item>
+    <item name="wifi.controller.rx">0</item>
+    <item name="wifi.controller.tx">0</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">0</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+</device>


### PR DESCRIPTION
fix phhusson/treble_experimentations#148

Additionally, for AOD we need to set "doze.display.supported=true"

Shall I add it to rw-system.sh?
(stock MIUI did it in /system/build.prop)