### PR TITLE
Moto/G6: use ro.vendor.product.name

### DIFF
--- a/Moto/G6/AndroidManifest.xml
+++ b/Moto/G6/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+motorola/ali_*"
+                android:requiredSystemPropertyName="ro.vendor.product.name"
+                android:requiredSystemPropertyValue="ali_retail"
 		android:priority="43"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
On my device, my fingerprint started with "+motorola/ali/*" which means this overlay did not function. Use ro.vendor.product.name and "ali_retail" which seems to be more uniform and less prone to failure. This is also what g6plus is using.