### PR TITLE
Initial support for the LG V40 ThinQ

### DIFF
--- a/LG/V40/Android.mk
+++ b/LG/V40/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-lg-v40
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/LG/V40/AndroidManifest.xml
+++ b/LG/V40/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.lg.v40"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+lge/judypn*"
+		android:priority="54"
+		android:isStatic="true" />
+</manifest>

--- a/LG/V40/res/values-land/notch.xml
+++ b/LG/V40/res/values-land/notch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">24dp</dimen>
+</resources>

--- a/LG/V40/res/values/notch.xml
+++ b/LG/V40/res/values/notch.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">94px</dimen>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">94px</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">24dp</dimen>
+	<string translatable="false" name="config_mainBuiltInDisplayCutout">M -250,0 L -250,94 L 250,94 L 250,0 Z</string>
+</resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -25,6 +25,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-huawei-telephony \
 	treble-overlay-lenovo-z5 \
 	treble-overlay-lg-g7 \
+	treble-overlay-lg-v40 \
 	treble-overlay-moto-g6 \
 	treble-overlay-moto-g6plus \
 	treble-overlay-nokia-b2n \


### PR DESCRIPTION
copy the LG G7 files and update Android.mk and AndroidManifest.xml.
The codename for the V40 is "judypn".