### PR TITLE
Add support for the Huawei Y6 (2018)/Y6 Prime (2018)

### DIFF
--- a/Huawei/msm8917/ATU/Android.mk
+++ b/Huawei/msm8917/ATU/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-huawei-ATU
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Huawei/msm8917/ATU/AndroidManifest.xml
+++ b/Huawei/msm8917/ATU/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="io.tenseventyseven.treble.huawei.ATU"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.hw.oemName"
+                android:requiredSystemPropertyValue="+ATU*"
+		android:priority="60"
+		android:isStatic="true" />
+</manifest>

--- a/Huawei/msm8917/ATU/res/values/config.xml
+++ b/Huawei/msm8917/ATU/res/values/config.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate.
+
+     NOTE: The naming convention is "config_camelCaseValue". Some legacy
+     entries do not follow the convention, but all new entries should. -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+	<!-- For some reason GPS works better when this array is set. -->
+	<string-array name="config_gpsParameters">
+		<item>XTRA_SERVER_1=http://xtrapath1.izatcloud.net/xtra3grc.bin</item>
+		<item>XTRA_SERVER_2=http://xtrapath2.izatcloud.net/xtra3grc.bin</item>
+		<item>XTRA_SERVER_3=http://xtrapath3.izatcloud.net/xtra3grc.bin</item>
+		<item>NTP_SERVER=time.izatcloud.net</item>
+		<item>SUPL_MODE=0</item>
+		<item>SUPL_HOST=NONE</item>
+		<item>SUPL_PORT=7275</item>
+		<item>SUPL_VER=0x20000</item>
+		<item>LPP_PROFILE=3</item>
+		<item>NMEA_PROVIDER=0</item>
+		<item>A_GLONASS_POS_PROTOCOL_SELECT=0</item>
+		<item>ERR_ESTIMATE=0</item>
+		<item>INTERMEDIATE_POS=1</item>
+		<item>SUPL_ES=0</item>
+		<item>GPS_LOCK=0</item>
+	</string-array>
+
+	<!-- If true, the screen can be rotated via the accelerometer in all 4
+	rotations as the default behavior. -->
+	<bool name="config_allowAllRotations">false</bool>
+
+	<!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
+	The N entries of this array define N + 1 control points as follows:
+	(1-based arrays)
+
+	Point 1:            (0, value[1]):             lux <= 0
+	Point 2:     (level[1], value[2]):  0        < lux <= level[1]
+	Point 3:     (level[2], value[3]):  level[2] < lux <= level[3]
+	...
+	Point N+1: (level[N], value[N+1]):  level[N] < lux
+
+	The control points must be strictly increasing.  Each control point
+	corresponds to an entry in the brightness backlight values arrays.
+	For example, if LUX == level[1] (first element of the levels array)
+	then the brightness will be determined by value[2] (second element
+	of the brightness values array).
+
+	Spline interpolation is used to determine the auto-brightness
+	backlight values for LUX levels between these control points.
+
+	Must be overridden in platform specific overlays -->
+	<integer-array name="config_autoBrightnessLevels">
+		<item>1</item>
+		<item>40</item>
+		<item>100</item>
+		<item>325</item>
+		<item>600</item>
+		<item>1250</item>
+		<item>2200</item>
+		<item>4000</item>
+		<item>10000</item>
+	</integer-array>
+
+	<!-- Array of output values for LCD backlight corresponding to the LUX values
+	in the config_autoBrightnessLevels array.  This array should have size one greater
+	than the size of the config_autoBrightnessLevels array.
+	The brightness values must be between 0 and 255 and be non-decreasing.
+	This must be overridden in platform specific overlays -->
+	<integer-array name="config_autoBrightnessLcdBacklightValues">
+		<item>11</item>   <!-- 0-1 -->
+		<item>22</item>   <!-- 1-40 -->
+		<item>47</item>   <!-- 40-100 -->
+		<item>61</item>   <!-- 100-325 -->
+		<item>84</item>   <!-- 325-600 -->
+		<item>107</item>  <!-- 600-1250 -->
+		<item>154</item>  <!-- 1250-2200 -->
+		<item>212</item>  <!-- 2200-4000 -->
+		<item>245</item>  <!-- 4000-10000 -->
+		<item>255</item>  <!-- 10000+ -->
+	</integer-array>
+
+	<!-- Minimum screen brightness allowed by the power manager. -->
+	<!-- ATU can go as low as 1. Behavior observed from stock. -->
+	<integer name="config_screenBrightnessSettingMinimum">1</integer>
+	<integer name="config_screenBrightnessDim">1</integer>
+
+	<!-- Flag indicating whether the we should enable the automatic brightness in Settings.
+	Software implementation will be used if config_hardware_auto_brightness_available is not set -->
+	<bool name="config_automatic_brightness_available">true</bool>
+
+	<!-- Boolean indicating if current platform supports BLE peripheral mode -->
+	<bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+
+	<!-- ComponentName of a dream to show whenever the system would otherwise have
+	gone to sleep.  When the PowerManager is asked to go to sleep, it will instead
+	try to start this dream if possible.  The dream should typically call startDozing()
+	to put the display into a low power state and allow the application processor
+	to be suspended.  When the dream ends, the system will go to sleep as usual.
+	Specify the component name or an empty string if none.
+	Note that doze dreams are not subject to the same start conditions as ordinary dreams.
+	Doze dreams will run whenever the power manager is in a dozing state. -->
+	<string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
+
+	<!-- If true, the doze component is not started until after the screen has been
+	turned off and the screen off animation has been performed. -->
+	<bool name="config_dozeAfterScreenOff">true</bool>
+
+	<!-- Control the behavior when the user double presses the power button.
+	0 - Nothing
+	1 - Toggle theater mode setting
+	2 - Brightness boost
+	-->
+	<integer name="config_doublePressOnPowerBehavior">0</integer>
+
+	<!-- Set this to true to enable the platform's auto-power-save modes like doze and
+	app standby.  These are not enabled by default because they require a standard
+	cloud-to-device messaging service for apps to interact correctly with the modes
+	(such as to be able to deliver an instant message to the device even when it is
+	dozing).  This should be enabled if you have such services and expect apps to
+	correctly use them when installed on your device.  Otherwise, keep this disabled
+	so that applications can still use their own mechanisms. -->
+	<bool name="config_enableAutoPowerModes">true</bool>
+
+	<!--  Maximum number of supported users -->
+	<integer name="config_multiuserMaximumUsers">5</integer>
+
+	<!-- Whether UI for multi user should be shown -->
+	<bool name="config_enableMultiUserUI">false</bool>
+
+	<!-- Power Management: Specifies whether to decouple the auto-suspend state of the
+	device from the display on/off state.
+	When false, autosuspend_disable() will be called before the display is turned on
+	and autosuspend_enable() will be called after the display is turned off.
+	This mode provides best compatibility for devices using legacy power management
+	features such as early suspend / late resume.
+	When true, autosuspend_display() and autosuspend_enable() will be called
+	independently of whether the display is being turned on or off.  This mode
+	enables the power manager to suspend the application processor while the
+	display is on.
+	This resource should be set to "true" when a doze component has been specified
+	to maximize power savings but not all devices support it.
+	Refer to autosuspend.h for details.
+	-->
+	<bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+
+	<!-- Indicate whether to allow the device to suspend when the screen is off
+	due to the proximity sensor.  This resource should only be set to true
+	if the sensor HAL correctly handles the proximity sensor as a wake-up source.
+	Otherwise, the device may fail to wake out of suspend reliably.
+	The default is false. -->
+	<bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
+
+	<!-- Power Management: Specifies whether to decouple the interactive state of the
+	device from the display on/off state.
+	When false, setInteractive(..., true) will be called before the display is turned on
+	and setInteractive(..., false) will be called after the display is turned off.
+	This mode provides best compatibility for devices that expect the interactive
+	state to be tied to the display state.
+	When true, setInteractive(...) will be called independently of whether the display
+	is being turned on or off.  This mode enables the power manager to reduce
+	clocks and disable the touch controller while the display is on.
+	This resource should be set to "true" when a doze component has been specified
+	to maximize power savings but not all devices support it.
+	Refer to power.h for details.
+	-->
+	<bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+
+
+	<!-- Screen brightness used to dim the screen while dozing in a very low power state.
+	May be less than the minimum allowed brightness setting
+	that can be set by the user. -->
+	<integer name="config_screenBrightnessDoze">5</integer>
+
+	<!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
+	<bool name="config_intrusiveNotificationLed">true</bool>
+
+	<!-- List of regexpressions describing the interface (if any) that represent tetherable
+	USB interfaces.  If the device doesn't want to support tething over USB this should
+	be empty.  An example would be "usb.*" -->
+	<string-array translatable="false" name="config_tether_usb_regexs">
+		<item>"usb\\d"</item>
+		<item>"rndis\\d"</item>
+	</string-array>
+
+	<!-- List of regexpressions describing the interface (if any) that represent tetherable
+	Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
+	should be empty.  An example would be "softap.*" -->
+	<string-array translatable="false" name="config_tether_wifi_regexs">
+		<item>"wlan0"</item>
+		<item>"softap.*"</item>
+	</string-array>
+
+	<!-- List of regexpressions describing the interface (if any) that represent tetherable
+	bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
+	should be empty. -->
+	<string-array translatable="false" name="config_tether_bluetooth_regexs">
+		<item>"bt-pan"</item>
+	</string-array>
+
+	<!-- Array of allowable ConnectivityManager network types for tethering -->
+	<!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
+	[0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->
+	<integer-array translatable="false" name="config_tether_upstream_types">
+		<item>0</item>
+		<item>1</item>
+		<item>5</item>
+		<item>7</item>
+	</integer-array>
+
+	<!-- Is the device capable of hot swapping an UICC Card -->
+	<bool name="config_hotswapCapable">true</bool>
+
+	<!-- Boolean indicating whether the HWC setColorTransform function can be performed efficiently
+	in hardware. -->
+	<bool name="config_setColorTransformAccelerated">true</bool>
+
+	<!-- Flag specifying whether VoLTE is available on device -->
+	<bool name="config_device_volte_available">true</bool>
+
+	<!-- Flag specifying whether VoLTE should be available for carrier: independent of
+	carrier provisioning. If false: hard disabled. If true: then depends on carrier
+	provisioning, availability etc -->
+	<bool name="config_carrier_volte_available">true</bool>
+
+	<!-- Flag specifying whether WFC over IMS is available on device -->
+	<bool name="config_device_wfc_ims_available">true</bool>
+
+	<!-- Flag specifying whether WFC over IMS should be available for carrier: independent of
+	carrier provisioning. If false: hard disabled. If true: then depends on carrier
+	provisioning, availability etc -->
+	<bool name="config_carrier_wfc_ims_available">true</bool>
+
+	<!-- Boolean indicating whether the wifi chipset supports background scanning mechanism.
+	This mechanism allows the host to remain in suspend state and the dongle to actively
+	scan and wake the host when a configured SSID is detected by the dongle. This chipset
+	capability can provide power savings when wifi needs to be always kept on. -->
+	<bool name="config_wifi_background_scan_support">true</bool>
+</resources>

--- a/Huawei/msm8917/ATU/res/xml/power_profile.xml
+++ b/Huawei/msm8917/ATU/res/xml/power_profile.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License")
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<device name="Android">
+  <!-- All values are in mA except as noted -->
+  <item name="none">0</item>
+  <item name="screen.on">100</item> <!-- min brite -->
+  <item name="bluetooth.active">97</item>
+  <item name="bluetooth.on">2.5</item>
+  <item name="bluetooth.at">2.5</item> <!-- TBD -->
+  <item name="screen.full">245</item> <!-- backlight 14 leds -->
+  <item name="wifi.on">1.4</item>
+  <item name="wifi.active">260</item>
+  <item name="wifi.scan">70</item>
+  <item name="dsp.audio">43</item> <!-- k3v5 -->
+  <item name="dsp.video">176</item>
+  <item name="radio.active">150</item>
+  <item name="gps.on">36</item>
+  <item name="battery.capacity">3000</item> <!-- 3000mAh -->
+  <item name="radio.scanning">102</item> <!-- TBD -->
+  <!-- Current consumed by the radio at different signal strengths, when paging  -->
+  <array name="radio.on"> <!-- 1 entry per signal strength bin, TBD -->
+    <value>13.0</value>
+    <value>10.0</value>
+    <value>10.0</value>
+    <value>10.0</value>
+    <value>10.0</value>
+  </array>
+  <array name="cpu.speeds">
+    <value>960000</value> <!-- 960 MHz CPU speed -->
+    <value>1094400</value> <!-- 1 GHz CPU speed -->
+    <value>1248000</value> <!-- 1.2 GHz CPU speed -->
+    <value>1401000</value><!-- 1.4 GHz CPU speed -->
+  </array>
+  <!-- Power consumption in suspend -->
+  <item name="cpu.idle">2.2</item> <!-- k3v5 -->
+  <!-- Power consumption due to wake lock held -->
+  <item name="cpu.awake">50</item> <!-- k3v5 -->
+  <!-- Power consumption at different speeds -->
+  <array name="cpu.active">
+    <value>137</value>
+    <value>147</value>
+    <value>158</value>
+    <value>169</value>
+  </array>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -12,6 +12,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-devinputjack \
 	treble-overlay-huawei \
 	treble-overlay-huawei-ANE \
+	treble-overlay-huawei-ATU \
 	treble-overlay-huawei-BKL \
 	treble-overlay-huawei-BND \
 	treble-overlay-huawei-CLT \


### PR DESCRIPTION
Adds appropriate power profile and minimum brightness setting to Huawei ATU-Lxx devices, the Y6 2018 (L21, L22, LX3) and Y6 Prime 2018 (L42).