### PR TITLE
Add Huawei Honor View 10 overlay

### DIFF
--- a/Huawei/kirin970/BKL/Android.mk
+++ b/Huawei/kirin970/BKL/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-huawei-BKL
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Huawei/kirin970/BKL/AndroidManifest.xml
+++ b/Huawei/kirin970/BKL/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.huawei.BKL"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.hw.oemName"
+                android:requiredSystemPropertyValue="+BKL*"
+		android:priority="42"
+		android:isStatic="true" />
+</manifest>

--- a/Huawei/kirin970/BKL/res/values/values.xml
+++ b/Huawei/kirin970/BKL/res/values/values.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>6</item>
+        <item>47</item>
+        <item>150</item>
+        <item>180</item>
+        <item>250</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>8</item>
+        <item>55</item>
+        <item>350</item>
+        <item>1600</item>
+        <item>2550</item>
+    </integer-array>
+    <integer name="config_autoBrightnessLightSensorRate">300</integer>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_bluetooth_hfp_inband_ringing_support">true</bool>
+    <bool name="config_cameraDoubleTapPowerGestureEnabled">false</bool>
+    <bool name="config_cellBroadcastAppLinks">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
+    <bool name="config_dynamic_bind_ims">true</bool>
+    <string name="config_ims_package">com.huawei.ims</string>
+    <integer name="config_mobile_mtu">1400</integer>
+    <integer name="config_screenBrightnessDark">4</integer>
+    <integer name="config_screenBrightnessDim">6</integer>
+    <integer name="config_screenBrightnessDoze">4</integer>
+    <integer name="config_screenBrightnessSettingDefault">33</integer>
+    <integer name="config_screenBrightnessSettingMinimum">4</integer>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <dimen name="navigation_bar_height">7.5mm</dimen>
+    <dimen name="navigation_bar_height_landscape">7.5mm</dimen>
+    <dimen name="navigation_bar_width">7.5mm</dimen>
+    <dimen name="notification_header_padding_top">8.0dip</dimen>
+    <dimen name="notification_header_padding_bottom">8.0dip</dimen>
+</resources>

--- a/Huawei/kirin970/BKL/res/xml/power_profile.xml
+++ b/Huawei/kirin970/BKL/res/xml/power_profile.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="battery.capacity">3000</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <item name="cpu.suspend">5</item>
+    <item name="cpu.idle">1.11</item>
+    <item name="cpu.active">2.55</item>
+    <item name="cpu.cluster_power.cluster0">2.11</item>
+    <item name="cpu.cluster_power.cluster1">2.22</item>
+    <array name="cpu.core_speeds.cluster0">
+        <value>300000</value>
+        <value>1000000</value>
+        <value>2000000</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>300000</value>
+        <value>1000000</value>
+        <value>2500000</value>
+        <value>3000000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>10</value>
+        <value>20</value>
+        <value>30</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>25</value>
+        <value>35</value>
+        <value>50</value>
+        <value>60</value>
+    </array>
+    <item name="ambient.on">0.5</item>
+    <item name="screen.on">100</item>
+    <item name="screen.full">800</item>
+    <item name="camera.flashlight">500</item>
+    <item name="camera.avg">600</item>
+    <item name="audio">100.0</item>
+    <item name="video">150.0</item>
+    <item name="gps.on">10</item>
+    <item name="radio.active">60</item>
+    <item name="radio.scanning">3</item>
+    <array name="radio.on">
+        <value>6</value>
+        <value>5</value>
+        <value>4</value>
+        <value>3</value>
+        <value>3</value>
+    </array>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -12,6 +12,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-devinputjack \
 	treble-overlay-huawei \
 	treble-overlay-huawei-ANE \
+	treble-overlay-huawei-BKL \
 	treble-overlay-huawei-BND \
 	treble-overlay-huawei-CLT \
 	treble-overlay-huawei-DUK \


### PR DESCRIPTION
overlay and power_profile based on the latest BKL-L09C432E4R1P9B159 (9.0.0.159) firmware

Tested with BKL-L09C432B172 (8.0.0.172) vendor