### PR TITLE
Add initial notch overlay for Xiaomi Mi Play, Redmi Note 7, Mi 9 and Mi 9 Lite(?)

### DIFF
--- a/OnePlus/OP6T/AndroidManifest.xml
+++ b/OnePlus/OP6T/AndroidManifest.xml
@@ -5,6 +5,6 @@
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
 		android:requiredSystemPropertyValue="+OnePlus/OnePlus6T/OnePlus6T*"
-		android:priority="60"
+		android:priority="74"
 		android:isStatic="true" />
 </manifest>

--- a/Xiaomi/Mi9/Android.mk
+++ b/Xiaomi/Mi9/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-mi9
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/Mi9/AndroidManifest.xml
+++ b/Xiaomi/Mi9/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.mi9"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*iaomi/cepheus*"
+		android:priority="90"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/Mi9/res/values/notch.xml
+++ b/Xiaomi/Mi9/res/values/notch.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">74px</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">24dp</dimen>
+	<string translatable="false" name="config_mainBuiltInDisplayCutout">M -58,0 L -58,74 L 58,74 L 58,0 Z</string>
+    <!-- Radius of the software rounded corners at the top of the display in its natural
+        orientation. If zero, the value of rounded_corner_radius is used. -->
+    <dimen name="rounded_corner_radius_top">100px</dimen>
+    <!-- Radius of the software rounded corners at the bottom of the display in its natural
+        orientation. If zero, the value of rounded_corner_radius is used. -->
+    <dimen name="rounded_corner_radius_bottom">110px</dimen>
+    </resources>

--- a/Xiaomi/Mi9Lite/Android.mk
+++ b/Xiaomi/Mi9Lite/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-mi9lite
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/Mi9Lite/AndroidManifest.xml
+++ b/Xiaomi/Mi9Lite/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.mi9lite"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*iaomi/grus*"
+		android:priority="89"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/Mi9Lite/res/values/notch.xml
+++ b/Xiaomi/Mi9Lite/res/values/notch.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">79px</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">24dp</dimen>
+	<string translatable="false" name="config_mainBuiltInDisplayCutout">M -62,0 L -62,79 L 62,79 L 62,0 Z</string>
+    <!-- Radius of the software rounded corners at the top of the display in its natural
+        orientation. If zero, the value of rounded_corner_radius is used. -->
+    <dimen name="rounded_corner_radius_top">108px</dimen>
+    <!-- Radius of the software rounded corners at the bottom of the display in its natural
+        orientation. If zero, the value of rounded_corner_radius is used. -->
+    <dimen name="rounded_corner_radius_bottom">126px</dimen>
+    </resources>

--- a/Xiaomi/MiPlay/Android.mk
+++ b/Xiaomi/MiPlay/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-miplay
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/MiPlay/AndroidManifest.xml
+++ b/Xiaomi/MiPlay/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.miplay"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*iaomi/lotus*"
+		android:priority="73"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/MiPlay/res/values-land/notch.xml
+++ b/Xiaomi/MiPlay/res/values-land/notch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">24dp</dimen>
+</resources>

--- a/Xiaomi/MiPlay/res/values/notch.xml
+++ b/Xiaomi/MiPlay/res/values/notch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">110px</dimen>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">110px</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">24dp</dimen>
+    </resources>

--- a/Xiaomi/RedmiNote7/Android.mk
+++ b/Xiaomi/RedmiNote7/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-redminote7
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/RedmiNote7/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote7/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.redminote7"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*iaomi/lavender*"
+		android:priority="75"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/RedmiNote7/res/values/notch.xml
+++ b/Xiaomi/RedmiNote7/res/values/notch.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">89px</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">24dp</dimen>
+	<string translatable="false" name="config_mainBuiltInDisplayCutout">M -176,0 L -176,89 L 176,89 L 176,0 Z</string>
+    </resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -45,6 +45,8 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-mi8lite \
 	treble-overlay-xiaomi-mi8pro \
 	treble-overlay-xiaomi-mi8se \
+	treble-overlay-xiaomi-mi9 \
+	treble-overlay-xiaomi-mi9lite \
 	treble-overlay-xiaomi-mia2 \
 	treble-overlay-xiaomi-mia2lite \
 	treble-overlay-xiaomi-mimax3 \
@@ -52,6 +54,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-mimix3 \
 	treble-overlay-xiaomi-mimix3-systemui \
 	treble-overlay-xiaomi-mipad4 \
+	treble-overlay-xiaomi-miplay \
 	treble-overlay-xiaomi-pocof1 \
 	treble-overlay-xiaomi-redmi6 \
 	treble-overlay-xiaomi-redmi6a \
@@ -59,6 +62,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redminote5 \
 	treble-overlay-xiaomi-redminote6pro \
 	treble-overlay-xiaomi-redminote6pro-systemui \
+	treble-overlay-xiaomi-redminote7 \
 	treble-overlay-xiaomi-redmis2 \
 
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Data of the two latter devices was extracted from a system app. Their existence and codenames are certain, so eventually they'll need a polishment one day, but we'll be prepared.