### PR TITLE
Add resources for Poco F1, Mi Play and Redmi Note 7

### DIFF
--- a/Xiaomi/MiPlay/res/values/config.xml
+++ b/Xiaomi/MiPlay/res/values/config.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>2</item>
+        <item>2</item>
+        <item>3</item>
+        <item>3</item>
+        <item>8</item>
+        <item>10</item>
+        <item>12</item>
+        <item>15</item>
+        <item>17</item>
+        <item>24</item>
+        <item>30</item>
+        <item>30</item>
+        <item>44</item>
+        <item>45</item>
+        <item>48</item>
+        <item>55</item>
+        <item>64</item>
+        <item>66</item>
+        <item>69</item>
+        <item>84</item>
+        <item>93</item>
+        <item>105</item>
+        <item>200</item>
+        <item>240</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>4</item>
+        <item>5</item>
+        <item>8</item>
+        <item>13</item>
+        <item>17</item>
+        <item>21</item>
+        <item>26</item>
+        <item>30</item>
+        <item>34</item>
+        <item>39</item>
+        <item>60</item>
+        <item>140</item>
+        <item>310</item>
+        <item>400</item>
+        <item>500</item>
+        <item>600</item>
+        <item>1000</item>
+        <item>1200</item>
+        <item>1500</item>
+        <item>3000</item>
+        <item>3500</item>
+        <item>4000</item>
+    </integer-array>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_setColorTransformAccelerated">false</bool>
+    <bool name="config_supportAudioSourceUnprocessed">false</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">false</bool>
+    <bool name="config_carrier_volte_available">false</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">false</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_lidControlsSleep">true</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">false</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">false</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">false</bool>
+    <bool name="config_displayBlanksAfterDoze">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">false</bool>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">200.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">2</integer>
+    <integer name="config_screenBrightnessDoze">1</integer>
+    <integer name="config_screenBrightnessSettingDefault">128</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">2</integer>
+    <integer name="config_bluetooth_idle_cur_ma">1</integer>
+    <integer name="config_bluetooth_operating_voltage_mv">4</integer>
+    <integer name="config_bluetooth_rx_cur_ma">2</integer>
+    <integer name="config_bluetooth_tx_cur_ma">3</integer>
+    <integer name="config_shutdownBatteryTemperature">600</integer>
+</resources>

--- a/Xiaomi/MiPlay/res/xml/power_profile.xml
+++ b/Xiaomi/MiPlay/res/xml/power_profile.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="screen.on">121.76</item>
+    <item name="screen.full">376.41</item>
+    <item name="bluetooth.on">2.1</item>
+    <item name="wifi.on">0.28</item>
+    <item name="wifi.active">171.25</item>
+    <item name="dsp.audio">40.42</item>
+    <item name="dsp.video">62.02</item>
+    <item name="camera.flashlight">315.41</item>
+    <item name="camera.avg">517.02</item>
+    <item name="gps.on">29</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>2301000</value>
+        <value>2215000</value>
+        <value>2139000</value>
+        <value>2074000</value>
+        <value>2009000</value>
+        <value>1944000</value>
+        <value>1879000</value>
+        <value>1814000</value>
+        <value>1750000</value>
+        <value>1617000</value>
+        <value>1484000</value>
+        <value>1351000</value>
+        <value>1218000</value>
+        <value>1085000</value>
+        <value>979000</value>
+        <value>900000</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>1114</value>
+        <value>1007</value>
+        <value>900</value>
+        <value>793</value>
+        <value>719</value>
+        <value>644</value>
+        <value>569</value>
+        <value>506</value>
+        <value>442</value>
+        <value>379</value>
+        <value>325</value>
+        <value>271</value>
+        <value>216</value>
+        <value>168</value>
+        <value>120</value>
+        <value>72</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>1800000</value>
+        <value>1682000</value>
+        <value>1579000</value>
+        <value>1491000</value>
+        <value>1402000</value>
+        <value>1314000</value>
+        <value>1226000</value>
+        <value>1138000</value>
+        <value>1050000</value>
+        <value>948000</value>
+        <value>846000</value>
+        <value>745000</value>
+        <value>643000</value>
+        <value>542000</value>
+        <value>460000</value>
+        <value>400000</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>678</value>
+        <value>600</value>
+        <value>522</value>
+        <value>446</value>
+        <value>396</value>
+        <value>348</value>
+        <value>300</value>
+        <value>262</value>
+        <value>226</value>
+        <value>188</value>
+        <value>159</value>
+        <value>129</value>
+        <value>100</value>
+        <value>75</value>
+        <value>51</value>
+        <value>26</value>
+    </array>
+    <item name="cpu.idle">9</item>
+    <item name="battery.capacity">3000</item>
+</device>

--- a/Xiaomi/PocoF1/res/values/config.xml
+++ b/Xiaomi/PocoF1/res/values/config.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>2</item>
+        <item>2</item>
+        <item>2</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>13</item>
+        <item>18</item>
+        <item>18</item>
+        <item>18</item>
+        <item>30</item>
+        <item>30</item>
+        <item>40</item>
+        <item>48</item>
+        <item>50</item>
+        <item>55</item>
+        <item>60</item>
+        <item>65</item>
+        <item>70</item>
+        <item>75</item>
+        <item>80</item>
+        <item>88</item>
+        <item>93</item>
+        <item>96</item>
+        <item>99</item>
+        <item>106</item>
+        <item>120</item>
+        <item>160</item>
+        <item>200</item>
+        <item>240</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>10</item>
+        <item>12</item>
+        <item>15</item>
+        <item>18</item>
+        <item>22</item>
+        <item>30</item>
+        <item>40</item>
+        <item>50</item>
+        <item>70</item>
+        <item>150</item>
+        <item>300</item>
+        <item>400</item>
+        <item>520</item>
+        <item>600</item>
+        <item>700</item>
+        <item>900</item>
+        <item>1100</item>
+        <item>1200</item>
+        <item>1300</item>
+        <item>1500</item>
+        <item>1800</item>
+        <item>2400</item>
+        <item>2800</item>
+        <item>3500</item>
+        <item>4000</item>
+    </integer-array>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_supportAudioSourceUnprocessed">true</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    <bool name="config_carrier_volte_available">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_intrusiveNotificationLed">false</bool>
+    <bool name="config_lidControlsSleep">true</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">false</bool>
+    <bool name="config_displayBlanksAfterDoze">false</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">200.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">2000</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">2</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessSettingDefault">128</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">2</integer>
+    <integer name="config_bluetooth_idle_cur_ma">1</integer>
+    <integer name="config_bluetooth_operating_voltage_mv">3300</integer>
+    <integer name="config_bluetooth_rx_cur_ma">2</integer>
+    <integer name="config_bluetooth_tx_cur_ma">3</integer>
+    <integer name="config_shutdownBatteryTemperature">600</integer>
+</resources>

--- a/Xiaomi/PocoF1/res/xml/power_profile.xml
+++ b/Xiaomi/PocoF1/res/xml/power_profile.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">103.44</item>
+    <item name="screen.full">284.85</item>
+    <item name="bluetooth.active">11.92</item>
+    <item name="bluetooth.on">0.85</item>
+    <item name="wifi.on">0.45</item>
+    <item name="wifi.active">0.1</item>
+    <item name="wifi.scan">4.1</item>
+    <item name="dsp.audio">3.75</item>
+    <item name="dsp.video">40.95</item>
+    <item name="camera.flashlight">160</item>
+    <item name="camera.avg">586</item>
+    <item name="gps.on">53.42</item>
+    <item name="radio.active">124.23</item>
+    <item name="radio.scanning">69.28</item>
+    <array name="radio.on">
+        <value>4.67</value>
+        <value>4.67</value>
+    </array>
+    <item name="modem.controller.idle">0</item>
+    <item name="modem.controller.rx">0</item>
+    <item name="modem.controller.tx">0</item>
+    <item name="modem.controller.voltage">0</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>300000</value>
+        <value>403200</value>
+        <value>480000</value>
+        <value>576000</value>
+        <value>652800</value>
+        <value>748800</value>
+        <value>825600</value>
+        <value>902400</value>
+        <value>979200</value>
+        <value>1056000</value>
+        <value>1132800</value>
+        <value>1228800</value>
+        <value>1324800</value>
+        <value>1420800</value>
+        <value>1516800</value>
+        <value>1612800</value>
+        <value>1689600</value>
+        <value>1766400</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>825600</value>
+        <value>902400</value>
+        <value>979200</value>
+        <value>1056000</value>
+        <value>1209600</value>
+        <value>1286400</value>
+        <value>1363200</value>
+        <value>1459200</value>
+        <value>1536000</value>
+        <value>1612800</value>
+        <value>1689600</value>
+        <value>1766400</value>
+        <value>1843200</value>
+        <value>1920000</value>
+        <value>1996800</value>
+        <value>2092800</value>
+        <value>2169600</value>
+        <value>2246400</value>
+        <value>2323200</value>
+        <value>2400000</value>
+        <value>2476800</value>
+        <value>2553600</value>
+        <value>2649600</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>43.59</value>
+        <value>45.08</value>
+        <value>46.3</value>
+        <value>47.18</value>
+        <value>47.45</value>
+        <value>49.1</value>
+        <value>50.08</value>
+        <value>52.19</value>
+        <value>53.39</value>
+        <value>53.7</value>
+        <value>57.24</value>
+        <value>59.74</value>
+        <value>62.74</value>
+        <value>65.57</value>
+        <value>69.21</value>
+        <value>73.43</value>
+        <value>77.77</value>
+        <value>81.46</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>78.72</value>
+        <value>84.21</value>
+        <value>89.26</value>
+        <value>94.8</value>
+        <value>105.51</value>
+        <value>111.87</value>
+        <value>118.53</value>
+        <value>128.99</value>
+        <value>137.49</value>
+        <value>146.46</value>
+        <value>154.62</value>
+        <value>173.55</value>
+        <value>179.36</value>
+        <value>209.68</value>
+        <value>236.7</value>
+        <value>246.27</value>
+        <value>268.23</value>
+        <value>275.14</value>
+        <value>292.46</value>
+        <value>316.98</value>
+        <value>341.44</value>
+        <value>371.42</value>
+        <value>416.77</value>
+    </array>
+    <item name="cpu.awake">8.1</item>
+    <item name="cpu.idle">4.35</item>
+    <array name="memory.bandwidths">
+        <value>22.7</value>
+    </array>
+    <item name="battery.capacity">4000</item>
+    <item name="wifi.controller.idle">0</item>
+    <item name="wifi.controller.rx">0</item>
+    <item name="wifi.controller.tx">0</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">0</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+</device>

--- a/Xiaomi/RedmiNote7/res/values/config.xml
+++ b/Xiaomi/RedmiNote7/res/values/config.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>4</item>
+        <item>5</item>
+        <item>8</item>
+        <item>13</item>
+        <item>17</item>
+        <item>21</item>
+        <item>26</item>
+        <item>30</item>
+        <item>34</item>
+        <item>39</item>
+        <item>60</item>
+        <item>140</item>
+        <item>310</item>
+        <item>400</item>
+        <item>500</item>
+        <item>600</item>
+        <item>1000</item>
+        <item>1200</item>
+        <item>1500</item>
+        <item>3000</item>
+        <item>3500</item>
+        <item>4000</item>
+    </integer-array>
+    <array name="config_autoBrightnessDisplayValuesNits">
+        <item>8</item>
+        <item>24</item>
+        <item>46</item>
+        <item>64</item>
+        <item>86</item>
+        <item>185</item>
+        <item>260</item>
+        <item>313</item>
+        <item>344</item>
+        <item>397</item>
+        <item>439</item>
+        <item>542</item>
+    </array>
+    <integer-array name="config_screenBrightnessBacklight">
+        <item>4</item>
+        <item>6</item>
+        <item>12</item>
+        <item>18</item>
+        <item>40</item>
+        <item>85</item>
+        <item>120</item>
+        <item>145</item>
+        <item>160</item>
+        <item>185</item>
+        <item>205</item>
+        <item>255</item>
+    </integer-array>
+    <array name="config_screenBrightnessNits">
+        <item>8</item>
+        <item>12</item>
+        <item>25</item>
+        <item>37</item>
+        <item>86</item>
+        <item>185</item>
+        <item>260</item>
+        <item>313</item>
+        <item>344</item>
+        <item>397</item>
+        <item>439</item>
+        <item>542</item>
+    </array>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="config_supportAudioSourceUnprocessed">true</bool>
+    <bool name="config_cameraDoubleTapPowerGestureEnabled">false</bool>
+    <bool name="config_sustainedPerformanceModeSupported">false</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">true</bool>
+    <bool name="config_lidControlsSleep">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_allowAutoBrightnessWhileDozing">false</bool>
+    <bool name="config_displayBlanksAfterDoze">true</bool>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_dozeAfterScreenOffByDefault">true</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+    <bool name="config_enableBurnInProtection">false</bool>
+    <integer name="config_shutdownBatteryTemperature">610</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
+    <integer name="config_screenBrightnessSettingDefault">1072</integer>
+    <integer name="config_screenBrightnessSettingMaximum">4095</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">2000</integer>
+    <integer name="config_bluetooth_operating_voltage_mv">3300</integer>
+    <integer name="config_screenBrightnessDim">1</integer>
+</resources>

--- a/Xiaomi/RedmiNote7/res/xml/power_profile.xml
+++ b/Xiaomi/RedmiNote7/res/xml/power_profile.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">103</item>
+    <item name="screen.full">300</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>633600</value>
+        <value>902400</value>
+        <value>1113600</value>
+        <value>1401600</value>
+        <value>1536000</value>
+        <value>1747200</value>
+        <value>1843200</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>13</value>
+        <value>20</value>
+        <value>28</value>
+        <value>36</value>
+        <value>45</value>
+        <value>55</value>
+        <value>65</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>1113600</value>
+        <value>1401600</value>
+        <value>1747200</value>
+        <value>1958400</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>75</value>
+        <value>105</value>
+        <value>166</value>
+        <value>205</value>
+    </array>
+    <item name="cpu.suspend">3.9</item>
+    <item name="cpu.idle">2</item>
+    <item name="cpu.active">1</item>
+    <item name="cpu.cluster_power.cluster0">1</item>
+    <item name="cpu.cluster_power.cluster1">1</item>
+    <item name="battery.capacity">4000</item>
+    <item name="bluetooth.active">80</item>
+    <item name="bluetooth.at">2</item>
+    <item name="bluetooth.on">2</item>
+    <item name="wifi.on">2</item>
+    <item name="wifi.active">125</item>
+    <item name="wifi.scan">180</item>
+    <item name="dsp.audio">45</item>
+    <item name="dsp.video">60</item>
+    <item name="camera.flashlight">200</item>
+    <item name="camera.avg">550</item>
+    <item name="gps.on">100</item>
+    <item name="radio.active">100</item>
+    <item name="radio.scanning">45</item>
+    <array name="radio.on">
+        <value>6</value>
+        <value>4</value>
+    </array>
+</device>

--- a/Xiaomi/RedmiNote7/res/xml/power_profile_test.xml
+++ b/Xiaomi/RedmiNote7/res/xml/power_profile_test.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="battery.capacity">3000</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <item name="cpu.suspend">5</item>
+    <item name="cpu.idle">1.11</item>
+    <item name="cpu.active">2.55</item>
+    <item name="cpu.cluster_power.cluster0">2.11</item>
+    <item name="cpu.cluster_power.cluster1">2.22</item>
+    <array name="cpu.core_speeds.cluster0">
+        <value>300000</value>
+        <value>1000000</value>
+        <value>2000000</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>300000</value>
+        <value>1000000</value>
+        <value>2500000</value>
+        <value>3000000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>10</value>
+        <value>20</value>
+        <value>30</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>25</value>
+        <value>35</value>
+        <value>50</value>
+        <value>60</value>
+    </array>
+    <item name="ambient.on">0.5</item>
+    <item name="screen.on">100</item>
+    <item name="screen.full">800</item>
+    <item name="camera.flashlight">500</item>
+    <item name="camera.avg">600</item>
+    <item name="audio">100.0</item>
+    <item name="video">150.0</item>
+    <item name="gps.on">10</item>
+    <item name="radio.active">60</item>
+    <item name="radio.scanning">3</item>
+    <array name="radio.on">
+        <value>6</value>
+        <value>5</value>
+        <value>4</value>
+        <value>3</value>
+        <value>3</value>
+    </array>
+</device>


### PR DESCRIPTION
For:
 
* beryllium ([Referrer](https://github.com/TadiT7/xiaomi_beryllium_dump/blob/beryllium-user-8.1.0-OPM1.171019.011-V9.6.18.0.OEJMIFD-release-keys/system/framework/framework-res.apk), and adjust some values from [this file](https://github.com/TadiT7/xiaomi_beryllium_dump/blob/beryllium-user-9-PKQ1.180729.001-8.11.23-release-keys/system/framework/framework-res.apk))
* lotus ([Referrer](https://github.com/TadiT7/xiaomi_lotus_dump/blob/lotus-user-8.1.0-O11019-V10.1.3.0.OFICNFI-release-keys/system/framework/framework-res.apk))
* lavender([Referrer](https://github.com/TadiT7/xiaomi_lavender_dump/blob/lavender-user-9-PKQ1.180904.001-V10.2.3.0.PFGCNXM-release-keys/system/system/framework/framework-res.apk))

All are blind-patched, maybe can fix auto brightness and battery usage for these devices.