### PR TITLE
Enable Always On Display (AOD) for LG G7 ThinQ

### DIFF
--- a/LG/G7/res/values/config.xml
+++ b/LG/G7/res/values/config.xml
@@ -69,7 +69,7 @@
     <bool name="config_wifi_background_scan_support">false</bool>
     <bool name="config_wifi_dual_band_support">true</bool>
 
-    <!--<string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
+    <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>-->
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
 </resources>


### PR DESCRIPTION
This change enables Always On Display for LG G7 ThinQ.
It works fine on my device, opposed to AOD on Oneplus 6 according to phhusson (reference: Discussion on the Telegram group).