### PR TITLE
Overlay: OnePlus 6/6T: properly check for device.

### DIFF
--- a/OnePlus/OP6/AndroidManifest.xml
+++ b/OnePlus/OP6/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+OnePlus/OnePlus6/OnePlus6*"
+                android:requiredSystemPropertyName="ro.boot.project_name"
+		android:requiredSystemPropertyValue="17819"
 		android:priority="11"
 		android:isStatic="true" />
 </manifest>

--- a/OnePlus/OP6T-SystemUI/AndroidManifest.xml
+++ b/OnePlus/OP6T-SystemUI/AndroidManifest.xml
@@ -3,7 +3,7 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="com.android.systemui"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+OnePlus/OnePlus6T/OnePlus6T*"
+                android:requiredSystemPropertyName="ro.boot.project_name"
+                android:requiredSystemPropertyValue="18801"
 		android:priority="60" />
 </manifest>

--- a/OnePlus/OP6T/AndroidManifest.xml
+++ b/OnePlus/OP6T/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-		android:requiredSystemPropertyValue="+OnePlus/OnePlus6T/OnePlus6T*"
+                android:requiredSystemPropertyName="ro.boot.project_name"
+		android:requiredSystemPropertyValue="18801"
 		android:priority="74"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
With all my respects, the current way of detecting if it´s
a OnePlus 6 or 6T is bit bad.

Switch to ro.boot.project_name, as we have done in Paranoid Android
for the last years, easiest way.

Signed-off-by: Hernán Castañón <herna@paranoidandroid.co>