### PR TITLE
Consider VoLTE carrier provisioned

### DIFF
--- a/HW-IMS/res/values/config.xml
+++ b/HW-IMS/res/values/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="config_ims_package">com.huawei.ims</string>
+	<bool name="config_carrier_volte_available">true</string>
 <!--	<bool name="config_dynamic_bind_ims">true</bool>-->
 </resources>


### PR DESCRIPTION
VoLTE must be provisioned or AOSP won't send calls via us, and if that happens, we get phantom calls, which causes double call logging and other issues.