### PR TITLE
Fix package name for moto g6 plus

### DIFF
--- a/Moto/G6Plus/AndroidManifest.xml
+++ b/Moto/G6Plus/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        package="me.phh.treble.overlay.oneplus.op6"
+        package="me.phh.treble.overlay.moto.g6plus"
         android:versionCode="1"
         android:versionName="1.0">
 	<!--


### PR DESCRIPTION
Otherwise it's overwritten by OnePlus 6 overlay