### PR TITLE
Changed Prop for Redmi Note 7 Overlay

### DIFF
--- a/Xiaomi/MiMix2S/AndroidManifest.xml
+++ b/Xiaomi/MiMix2S/AndroidManifest.xml
@@ -3,7 +3,7 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint_real"
 		android:requiredSystemPropertyValue="+Xiaomi/polaris*"
 		android:priority="13"
 		android:isStatic="true" />

--- a/Xiaomi/RedmiNote7/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote7/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+*iaomi/lavender*"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint_real"
+                android:requiredSystemPropertyValue="+xiaomi/lavender*"
 		android:priority="75"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Xiaomi uses the prop ro.vendor.build.fingerprint_real for vendor fingerprint.

Redmi Note 7 uses the MiMix2 overlay, because on the prop ro.vendor.build.fingerprint a polaris device is shown in /vendor/build.prop.