### PR TITLE
Add Overlay for Infinix S4 (X626)

### DIFF
--- a/Infinix/S4/Android.mk
+++ b/Infinix/S4/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-infinix-s4
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Infinix/S4/AndroidManifest.xml
+++ b/Infinix/S4/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.infinix.s4"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+		android:requiredSystemPropertyValue="+Infinix/H624/Infinix-X626*"
+		android:priority="24"
+		android:isStatic="true" />
+</manifest>

--- a/Infinix/S4/res/values/config.xml
+++ b/Infinix/S4/res/values/config.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="networkAttributes">
+        <item>wifi,1,1,1,-1,true</item>
+        <item>mobile,0,0,0,-1,true</item>
+        <item>mobile_mms,2,0,2,60000,true</item>
+        <item>mobile_supl,3,0,2,60000,true</item>
+        <item>mobile_dun,4,0,2,60000,true</item>
+        <item>mobile_hipri,5,0,3,60000,true</item>
+        <item>mobile_fota,10,0,2,60000,true</item>
+        <item>mobile_ims,11,0,-1,-1,true</item>
+        <item>mobile_cbs,12,0,2,60000,true</item>
+        <item>wifi_p2p,13,1,0,-1,true</item>
+        <item>mobile_ia,14,0,2,-1,true</item>
+        <item>mobile_emergency,15,0,2,-1,true</item>
+        <item>mobile_wap,21,0,3,60000,true</item>
+        <item>mobile_xcap,25,0,3,60000,true</item>
+        <item>mobile_rcs,26,0,3,60000,true</item>
+        <item>mobile_bip,27,0,3,60000,true</item>
+        <item>mobile_vsim,28,0,-1,60000,true</item>
+        <item>mobile_preempt,29,0,9,60000,true</item>
+    </string-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>128</item>
+        <item>256</item>
+        <item>384</item>
+        <item>512</item>
+        <item>640</item>
+        <item>768</item>
+        <item>896</item>
+        <item>1024</item>
+        <item>2048</item>
+        <item>4096</item>
+        <item>6144</item>
+        <item>8192</item>
+        <item>10240</item>
+        <item>12288</item>
+        <item>14336</item>
+        <item>16384</item>
+        <item>18432</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>8</item>
+        <item>64</item>
+        <item>98</item>
+        <item>104</item>
+        <item>110</item>
+        <item>116</item>
+        <item>122</item>
+        <item>128</item>
+        <item>134</item>
+        <item>182</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+    </integer-array>
+    <string-array name="config_tether_usb_regexs">
+        <item>rndis\\d</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>ap\\d</item>
+    </string-array>
+    <string-array name="config_tether_bluetooth_regexs">
+        <item>bt-pan</item>
+        <item>bt-dun</item>
+    </string-array>
+    <string-array name="config_defaultPinnerServiceFiles">
+        <item>/system/framework/arm/boot-mediatek-framework.vdex</item>
+        <item>/system/lib/libjavacrypto.so</item>
+        <item>/system/lib/libhidltransport.so</item>
+        <item>/system/framework/arm/boot-core-libart.oat</item>
+        <item>/system/framework/arm/boot-conscrypt.oat</item>
+        <item>/system/framework/arm/boot-core-libart.vdex</item>
+        <item>/system/framework/arm/boot-ext.vdex</item>
+        <item>/system/framework/arm/boot.vdex</item>
+        <item>/system/framework/arm/boot-framework.vdex</item>
+    </string-array>
+    <string-array name="config_ephemeralResolverPackage">
+        <item>com.google.android.gms</item>
+    </string-array>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_device_volte_available">false</bool>
+    <bool name="config_device_vt_available">false</bool>
+    <bool name="config_device_wfc_ims_available">false</bool>
+    <bool name="config_dynamic_bind_ims">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_enableMultiUserUI">false</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_cellBroadcastAppLinks">true</bool>
+    <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
+    <bool name="config_enableAutoPowerModes">true</bool>
+    <bool name="config_enableNetworkLocationOverlay">true</bool>
+    <bool name="config_enableFusedLocationOverlay">true</bool>
+    <integer name="config_multiuserMaximumUsers">5</integer>
+    <integer name="config_screenBrightnessSettingMinimum">2</integer>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">6000</integer>
+</resources>

--- a/Infinix/S4/res/values/notch.xml
+++ b/Infinix/S4/res/values/notch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">50px</dimen>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">50px</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">28.0dip</dimen>
+</resources>

--- a/Infinix/S4/res/xml/power_profile.xml
+++ b/Infinix/S4/res/xml/power_profile.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">45.5</item>
+    <item name="screen.full">335</item>
+    <item name="bluetooth.active">73.5</item>
+    <item name="bluetooth.on">5.8</item>
+    <item name="wifi.on">4.9</item>
+    <item name="wifi.active">72.3</item>
+    <item name="wifi.scan">5</item>
+    <item name="dsp.audio">250.2</item>
+    <item name="dsp.video">270</item>
+    <item name="camera.flashlight">257</item>
+    <item name="camera.avg">756</item>
+    <item name="gps.on">4.4</item>
+    <item name="radio.active">320</item>
+    <item name="radio.scanning">5.8</item>
+    <array name="radio.on">
+        <value>5.8</value>
+        <value>5.8</value>
+    </array>
+    <item name="modem.controller.idle">5.8</item>
+    <item name="modem.controller.rx">226</item>
+    <item name="modem.controller.tx">226</item>
+    <item name="modem.controller.voltage">4.0</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>850000</value>
+        <value>918000</value>
+        <value>987000</value>
+        <value>1056000</value>
+        <value>1125000</value>
+        <value>1216000</value>
+        <value>1308000</value>
+        <value>1400000</value>
+        <value>1466000</value>
+        <value>1533000</value>
+        <value>1633000</value>
+        <value>1700000</value>
+        <value>1767000</value>
+        <value>1834000</value>
+        <value>1917000</value>
+        <value>2001000</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>9.3</value>
+        <value>9.3</value>
+        <value>10.6</value>
+        <value>11.6</value>
+        <value>13.3</value>
+        <value>15.0</value>
+        <value>17.2</value>
+        <value>20.2</value>
+        <value>22.8</value>
+        <value>26.3</value>
+        <value>27.4</value>
+        <value>29.7</value>
+        <value>30.2</value>
+        <value>32.1</value>
+        <value>33.9</value>
+        <value>38.5</value>
+    </array>
+    <item name="cpu.idle">4.1</item>
+    <array name="memory.bandwidths">
+        <value>1.3</value>
+    </array>
+    <item name="battery.capacity">4000</item>
+    <item name="wifi.controller.idle">4.9</item>
+    <item name="wifi.controller.rx">72.3</item>
+    <item name="wifi.controller.tx">72.3</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">4.0</item>
+    <array name="wifi.batchedscan">
+        <value>64.2</value>
+        <value>64.2</value>
+        <value>64.2</value>
+        <value>64.2</value>
+        <value>64.2</value>
+    </array>
+</device>

--- a/Infinix/Zero6/Android.mk
+++ b/Infinix/Zero6/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-infinix-zero6
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Infinix/Zero6/AndroidManifest.xml
+++ b/Infinix/Zero6/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.infinix.zero6"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*Infinix/Q6361A/Infinix-X620*"
+		android:priority="98"
+		android:isStatic="true" />
+</manifest>

--- a/Infinix/Zero6/res/values-land/notch.xml
+++ b/Infinix/Zero6/res/values-land/notch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">24dp</dimen>
+</resources>

--- a/Infinix/Zero6/res/values/config.xml
+++ b/Infinix/Zero6/res/values/config.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_auto_attach_data_on_creation">false</bool>
+    <bool name="config_nightDisplayAvailable">true</bool>
+    <bool name="config_lidControlsSleep">true</bool>
+    <bool name="config_dozePulsePickup">true</bool>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessSettingDefault">66</integer>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">10</integer>
+    <integer name="config_brightness_ramp_rate_fast">180</integer>
+    <integer name="config_brightness_ramp_rate_slow">60</integer>
+    <integer name="config_multiuserMaximumUsers">5</integer>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">299.9939%</fraction>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>4</item>
+        <item>5</item>
+        <item>8</item>
+        <item>13</item>
+        <item>17</item>
+        <item>21</item>
+        <item>26</item>
+        <item>30</item>
+        <item>34</item>
+        <item>39</item>
+        <item>60</item>
+        <item>140</item>
+        <item>310</item>
+        <item>400</item>
+        <item>500</item>
+        <item>600</item>
+        <item>1000</item>
+        <item>1200</item>
+        <item>1500</item>
+        <item>3000</item>
+        <item>3500</item>
+        <item>4000</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>2</item>
+        <item>2</item>
+        <item>3</item>
+        <item>3</item>
+        <item>8</item>
+        <item>10</item>
+        <item>12</item>
+        <item>15</item>
+        <item>17</item>
+        <item>24</item>
+        <item>30</item>
+        <item>30</item>
+        <item>44</item>
+        <item>45</item>
+        <item>48</item>
+        <item>55</item>
+        <item>64</item>
+        <item>66</item>
+        <item>69</item>
+        <item>84</item>
+        <item>93</item>
+        <item>105</item>
+        <item>200</item>
+        <item>240</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessButtonBacklightValues">
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+        <item>0</item>
+    </integer-array>
+</resources>

--- a/Infinix/Zero6/res/values/notch.xml
+++ b/Infinix/Zero6/res/values/notch.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">86.0px</dimen>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">86.0px</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">24dp</dimen>
+	<dimen name="rounded_corner_radius">86.0px</dimen>
+	<string translatable="false" name="config_mainBuiltInDisplayCutout">M -130,0 L -130,86 L 130,86 L 130,0 Z</string>
+</resources>

--- a/Infinix/Zero6/res/xml/power_profile.xml
+++ b/Infinix/Zero6/res/xml/power_profile.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">98</item>
+    <item name="screen.full">315</item>
+    <item name="bluetooth.active">95</item>
+    <item name="bluetooth.on">1.2</item>
+    <item name="wifi.on">1.6</item>
+    <item name="wifi.active">110</item>
+    <item name="wifi.scan">185</item>
+    <item name="dsp.audio">23.25</item>
+    <item name="dsp.video">96.5</item>
+    <item name="camera.avg">316</item>
+    <item name="camera.flashlight">390</item>
+    <item name="gps.on">83</item>
+    <item name="radio.active">84</item>
+    <item name="radio.scanning">115</item>
+    <array name="radio.on">
+        <value>17</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>633600</value>
+        <value>902400</value>
+        <value>1113600</value>
+        <value>1401600</value>
+        <value>1536000</value>
+        <value>1612800</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>1113600</value>
+        <value>1401600</value>
+        <value>1747200</value>
+        <value>1804800</value>
+    </array>
+    <item name="cpu.idle">5.4</item>
+    <item name="cpu.awake">15</item>
+    <array name="cpu.active.cluster0">
+        <value>16.65</value>
+        <value>46.31</value>
+        <value>50.77</value>
+        <value>63.93</value>
+        <value>82.85</value>
+        <value>87.9</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>112.1</value>
+        <value>145.9</value>
+        <value>198.3</value>
+        <value>223.5</value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <item name="battery.capacity">3650</item>
+    <array name="wifi.batchedscan">
+        <value>.0185</value>
+        <value>.1502</value>
+        <value>1.188</value>
+        <value>9.486</value>
+        <value>75.87</value>
+    </array>
+</device>


### PR DESCRIPTION
- **Infinix S4 Overlay** serves majorly to fix the notch configuration and automatic brightness on treble custom Roms.
- **Infinix ZERO 6 Overlay** fixes automatic brightness on custom Roms especially treble GSIs while at the same time bringing fixes for the notch configuration including proper handling of WhatsApp statuses display.