### PR TITLE
Add Overlay for Infinix NOTE 5 (X604)

### DIFF
--- a/Infinix/Note5/Android.mk
+++ b/Infinix/Note5/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-infinix-note5
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Infinix/Note5/AndroidManifest.xml
+++ b/Infinix/Note5/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.infinix.note5"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+		android:requiredSystemPropertyValue="+Infinix/H633/Infinix-X604_sprout*"
+		android:priority="110"
+		android:isStatic="true" />
+</manifest>

--- a/Infinix/Note5/res/values/config.xml
+++ b/Infinix/Note5/res/values/config.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>3</item>
+        <item>3</item>
+        <item>3</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>8</item>
+        <item>12</item>
+        <item>12</item>
+        <item>18</item>
+        <item>18</item>
+        <item>18</item>
+        <item>27</item>
+        <item>27</item>
+        <item>27</item>
+        <item>32</item>
+        <item>32</item>
+        <item>32</item>
+        <item>37</item>
+        <item>46</item>
+        <item>49</item>
+        <item>52</item>
+        <item>53</item>
+        <item>59</item>
+        <item>61</item>
+        <item>64</item>
+        <item>70</item>
+        <item>77</item>
+        <item>85</item>
+        <item>97</item>
+        <item>107</item>
+        <item>120</item>
+        <item>131</item>
+        <item>149</item>
+        <item>175</item>
+        <item>186</item>
+        <item>209</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>10</item>
+        <item>12</item>
+        <item>15</item>
+        <item>18</item>
+        <item>22</item>
+        <item>30</item>
+        <item>40</item>
+        <item>50</item>
+        <item>80</item>
+        <item>110</item>
+        <item>155</item>
+        <item>173</item>
+        <item>300</item>
+        <item>387</item>
+        <item>492</item>
+        <item>533</item>
+        <item>726</item>
+        <item>883</item>
+        <item>1023</item>
+        <item>1222</item>
+        <item>1501</item>
+        <item>1733</item>
+        <item>2034</item>
+        <item>2227</item>
+        <item>2517</item>
+        <item>3042</item>
+        <item>3495</item>
+        <item>3998</item>
+        <item>4472</item>
+    </integer-array>
+    <string-array name="networkAttributes">
+        <item>wifi,1,1,1,-1,true</item>
+        <item>mobile,0,0,0,-1,true</item>
+        <item>mobile_mms,2,0,2,60000,true</item>
+        <item>mobile_supl,3,0,2,60000,true</item>
+        <item>mobile_dun,4,0,2,60000,true</item>
+        <item>mobile_hipri,5,0,3,60000,true</item>
+        <item>mobile_fota,10,0,2,60000,true</item>
+        <item>mobile_ims,11,0,-1,-1,true</item>
+        <item>mobile_cbs,12,0,2,60000,true</item>
+        <item>wifi_p2p,13,1,0,-1,true</item>
+        <item>mobile_ia,14,0,2,-1,true</item>
+        <item>mobile_emergency,15,0,2,-1,true</item>
+        <item>mobile_wap,21,0,3,60000,true</item>
+        <item>mobile_xcap,25,0,3,60000,true</item>
+        <item>mobile_rcs,26,0,3,60000,true</item>
+        <item>mobile_bip,27,0,3,60000,true</item>
+        <item>mobile_vsim,28,0,-1,60000,true</item>
+        <item>mobile_preempt,29,0,9,60000,true</item>
+    </string-array>
+    <string-array name="config_tether_usb_regexs">
+        <item>rndis\\d</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>ap\\d</item>
+    </string-array>
+    <string-array name="config_tether_bluetooth_regexs">
+        <item>bt-pan</item>
+        <item>bt-dun</item>
+    </string-array>
+    <string-array name="config_defaultPinnerServiceFiles">
+        <item>/system/framework/arm/boot-mediatek-framework.vdex</item>
+        <item>/system/lib/libjavacrypto.so</item>
+        <item>/system/lib/libhidltransport.so</item>
+        <item>/system/framework/arm/boot-core-libart.oat</item>
+        <item>/system/framework/arm/boot-conscrypt.oat</item>
+        <item>/system/framework/arm/boot-core-libart.vdex</item>
+        <item>/system/framework/arm/boot-ext.vdex</item>
+        <item>/system/framework/arm/boot.vdex</item>
+        <item>/system/framework/arm/boot-framework.vdex</item>
+    </string-array>
+    <string-array name="config_ephemeralResolverPackage">
+        <item>com.google.android.gms</item>
+    </string-array>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_carrier_volte_available">true</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_device_wfc_ims_available">false</bool>
+    <bool name="config_dynamic_bind_ims">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_enableMultiUserUI">true</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_enableAutoPowerModes">true</bool>
+    <bool name="config_enableNetworkLocationOverlay">true</bool>
+    <bool name="config_enableFusedLocationOverlay">true</bool>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">200.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">6000</integer>
+    <integer name="config_screenBrightnessDim">1</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessSettingDefault">67</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_multiuserMaximumUsers">4</integer>
+    <integer name="config_screenBrightnessSettingMinimum">2</integer>
+    <integer name="config_screenBrightnessDark">2</integer>
+</resources>

--- a/Infinix/Note5/res/xml/power_profile.xml
+++ b/Infinix/Note5/res/xml/power_profile.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android"> //PPD:add power profile by zhenbang.yu 20181022 start
+<item name="screen.on">81</item>
+    <item name="screen.full">300</item>
+    <item name="bluetooth.active">40</item>
+    <item name="bluetooth.on">1</item>
+    <item name="wifi.on">0.2</item>
+    <item name="wifi.active">250</item>
+    <item name="wifi.scan">46</item>
+    <item name="dsp.audio">20</item>
+    <item name="dsp.video">71</item>
+    <item name="radio.active">160</item>
+    <item name="radio.scanning">17.7</item>
+    <array name="radio.on">
+        <value>4.9</value>
+        <value>4.9</value>
+    </array>
+    <item name="battery.capacity">4500</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>338000</value>
+        <value>481000</value>
+        <value>624000</value>
+        <value>715000</value>
+        <value>793000</value>
+        <value>884000</value>
+        <value>1001000</value>
+        <value>1105000</value>
+        <value>1183000</value>
+        <value>1235000</value>
+        <value>1300000</value>
+        <value>1365000</value>
+        <value>1404000</value>
+        <value>1430000</value>
+        <value>1482000</value>
+        <value>1508000</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>520000</value>
+        <value>715000</value>
+        <value>910000</value>
+        <value>1040000</value>
+        <value>1170000</value>
+        <value>1287000</value>
+        <value>1456000</value>
+        <value>1586000</value>
+        <value>1690000</value>
+        <value>1742000</value>
+        <value>1807000</value>
+        <value>1859000</value>
+        <value>1911000</value>
+        <value>1937000</value>
+        <value>1976000</value>
+        <value>2002000</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>3.25</value>
+        <value>5.23</value>
+        <value>7.20</value>
+        <value>8.68</value>
+        <value>10.18</value>
+        <value>11.98</value>
+        <value>14.46</value>
+        <value>16.75</value>
+        <value>18.77</value>
+        <value>20.6</value>
+        <value>22.60</value>
+        <value>30.08</value>
+        <value>33.09</value>
+        <value>33.64</value>
+        <value>36.36</value>
+        <value>37.42</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>12.24</value>
+        <value>15</value>
+        <value>23.26</value>
+        <value>25.06</value>
+        <value>28.89</value>
+        <value>33.35</value>
+        <value>41.44</value>
+        <value>47.63</value>
+        <value>53.85</value>
+        <value>58.05</value>
+        <value>64.04</value>
+        <value>67.23</value>
+        <value>68.28</value>
+        <value>69.66</value>
+        <value>73.17</value>
+        <value>74.69</value>
+    </array>
+    <item name="cpu.idle">3.59</item>
+    <array name="wifi.batchedscan">
+        <value>.2</value>
+        <value>2</value>
+        <value>20</value>
+        <value>200</value>
+        <value>500</value>
+    </array> //PPD:add power profile by zhenbang.yu 20181022 end
+</device>


### PR DESCRIPTION
This overlay majorly brings in automatic brightness to the Infinix NOTE 5 which is not enabled by default on the GSIs.