### PR TITLE
[daisy] update overlay

### DIFF
--- a/Xiaomi/MiA2Lite/res/values/config.xml
+++ b/Xiaomi/MiA2Lite/res/values/config.xml
@@ -1,60 +1,191 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer-array name="config_autoBrightnessLcdBacklightValues">
+    <array name="config_autoBrightnessButtonBacklightValues" />
+    <array name="config_autoBrightnessDisplayValuesNits">
+        <item>7.702998</item>
+        <item>32.31226</item>
+        <item>38.786167</item>
+        <item>43.30993</item>
+        <item>46.851162</item>
+        <item>55.90478</item>
+        <item>61.334614</item>
+        <item>68.4388</item>
+        <item>75.59099</item>
+        <item>82.8686</item>
+        <item>91.49397</item>
+        <item>102.49851</item>
+        <item>118.8174</item>
+        <item>144.68486</item>
+        <item>180.69225</item>
+        <item>225.84135</item>
+        <item>292.46844</item>
+        <item>377.05084</item>
+        <item>481.93427</item>
+    </array>
+    <array name="config_autoBrightnessLcdBacklightValues" />
+    <integer-array name="config_autoBrightnessLevels">
         <item>1</item>
         <item>2</item>
-        <item>2</item>
         <item>3</item>
-        <item>3</item>
-        <item>5</item>
-        <item>5</item>
-        <item>12</item>
+        <item>4</item>
+        <item>8</item>
         <item>12</item>
         <item>20</item>
-        <item>20</item>
-        <item>39</item>
-        <item>39</item>
-        <item>43</item>
-        <item>43</item>
+        <item>33</item>
         <item>55</item>
-        <item>55</item>
-        <item>63</item>
-        <item>63</item>
-        <item>84</item>
-        <item>93</item>
-        <item>105</item>
-        <item>120</item>
-        <item>180</item>
-        <item>240</item>
-        <item>255</item>
+        <item>90</item>
+        <item>148</item>
+        <item>245</item>
+        <item>403</item>
+        <item>665</item>
+        <item>1097</item>
+        <item>1808</item>
+        <item>2981</item>
+        <item>5000</item>
     </integer-array>
-    <integer-array name="config_autoBrightnessLevels">
+    <array name="config_minimumBrightnessCurveNits">
+        <item>0.0</item>
+        <item>50.0</item>
+        <item>90.0</item>
+    </array>
+    <integer-array name="config_screenBrightnessBacklight">
         <item>1</item>
         <item>2</item>
         <item>3</item>
         <item>4</item>
         <item>5</item>
         <item>6</item>
+        <item>7</item>
         <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
         <item>13</item>
+        <item>14</item>
+        <item>15</item>
+        <item>16</item>
         <item>17</item>
-        <item>21</item>
-        <item>26</item>
+        <item>18</item>
+        <item>19</item>
+        <item>20</item>
+        <item>25</item>
         <item>30</item>
-        <item>34</item>
+        <item>35</item>
+        <item>40</item>
+        <item>45</item>
+        <item>50</item>
+        <item>55</item>
+        <item>60</item>
+        <item>65</item>
+        <item>70</item>
+        <item>75</item>
+        <item>80</item>
+        <item>85</item>
+        <item>90</item>
+        <item>95</item>
+        <item>100</item>
+        <item>105</item>
+        <item>110</item>
+        <item>115</item>
+        <item>120</item>
+        <item>125</item>
+        <item>130</item>
+        <item>135</item>
         <item>140</item>
-        <item>310</item>
-        <item>400</item>
-        <item>500</item>
-        <item>600</item>
-        <item>1000</item>
-        <item>1200</item>
-        <item>1500</item>
-        <item>2000</item>
-        <item>3000</item>
-        <item>3500</item>
-        <item>4000</item>
+        <item>145</item>
+        <item>150</item>
+        <item>155</item>
+        <item>160</item>
+        <item>165</item>
+        <item>170</item>
+        <item>175</item>
+        <item>180</item>
+        <item>185</item>
+        <item>190</item>
+        <item>195</item>
+        <item>200</item>
+        <item>205</item>
+        <item>210</item>
+        <item>215</item>
+        <item>220</item>
+        <item>225</item>
+        <item>230</item>
+        <item>235</item>
+        <item>240</item>
+        <item>245</item>
+        <item>250</item>
+        <item>255</item>
     </integer-array>
+    <array name="config_screenBrightnessNits">
+        <item>2.685</item>
+        <item>3.343</item>
+        <item>4.13</item>
+        <item>5.216</item>
+        <item>6.308</item>
+        <item>7.565</item>
+        <item>9.269</item>
+        <item>10.98</item>
+        <item>13.25</item>
+        <item>15.49</item>
+        <item>18.42</item>
+        <item>20.6</item>
+        <item>22.71</item>
+        <item>24.68</item>
+        <item>26.31</item>
+        <item>28.39</item>
+        <item>30.34</item>
+        <item>32.39</item>
+        <item>33.94</item>
+        <item>35.94</item>
+        <item>45.12</item>
+        <item>54</item>
+        <item>62.31</item>
+        <item>70.73</item>
+        <item>78.85</item>
+        <item>86.41</item>
+        <item>93.53</item>
+        <item>102.3</item>
+        <item>109.1</item>
+        <item>118.7</item>
+        <item>126.4</item>
+        <item>136.9</item>
+        <item>147.8</item>
+        <item>158.9</item>
+        <item>168.3</item>
+        <item>177.4</item>
+        <item>186.6</item>
+        <item>195.7</item>
+        <item>204.5</item>
+        <item>214</item>
+        <item>221.8</item>
+        <item>234</item>
+        <item>242.1</item>
+        <item>250.6</item>
+        <item>263.4</item>
+        <item>272.4</item>
+        <item>282.5</item>
+        <item>296.3</item>
+        <item>305.6</item>
+        <item>315.3</item>
+        <item>329.8</item>
+        <item>339.8</item>
+        <item>349.7</item>
+        <item>357.4</item>
+        <item>364.6</item>
+        <item>374.6</item>
+        <item>384.9</item>
+        <item>392.5</item>
+        <item>402.8</item>
+        <item>413.6</item>
+        <item>421.6</item>
+        <item>432.2</item>
+        <item>440.3</item>
+        <item>448.3</item>
+        <item>459.2</item>
+        <item>467.6</item>
+        <item>478.5</item>
+    </array>
     <bool name="config_automatic_brightness_available">true</bool>
     <bool name="config_setColorTransformAccelerated">true</bool>
     <bool name="config_supportAudioSourceUnprocessed">false</bool>
@@ -66,17 +197,17 @@
     <bool name="config_device_vt_available">true</bool>
     <bool name="config_device_wfc_ims_available">true</bool>
     <bool name="config_hotswapCapable">true</bool>
-    <bool name="config_lidControlsSleep">false</bool>
+    <bool name="config_lidControlsSleep">true</bool>
     <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
     <bool name="config_wifi_background_scan_support">true</bool>
     <bool name="config_wifi_batched_scan_supported">true</bool>
     <bool name="config_wifi_dual_band_support">true</bool>
     <bool name="config_dozeAlwaysOnDisplayAvailable">false</bool>
-    <bool name="config_displayBlanksAfterDoze">false</bool>
-    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">false</bool>
-    <fraction name="config_autoBrightnessAdjustmentMaxGamma">299.99695%</fraction>
-    <fraction name="config_maximumScreenDimRatio">20.000004%</fraction>
-    <integer name="config_autoBrightnessBrighteningLightDebounce">4000</integer>
+    <bool name="config_displayBlanksAfterDoze">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">200.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
     <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
     <integer name="config_screenBrightnessDark">1</integer>
     <integer name="config_screenBrightnessDim">1</integer>

--- a/Xiaomi/MiA2Lite/res/values/notch.xml
+++ b/Xiaomi/MiA2Lite/res/values/notch.xml
@@ -18,10 +18,10 @@
 -->
 <resources>
     <!-- Height of the status bar in portrait -->
-    <dimen name="status_bar_height_portrait">94px</dimen>
+    <dimen name="status_bar_height_portrait">89px</dimen>
     <!-- Height of the status bar -->
-    <dimen name="status_bar_height">94px</dimen>
+    <dimen name="status_bar_height">89px</dimen>
     <!-- Height of the status bar in landscape -->
     <dimen name="status_bar_height_landscape">24dp</dimen>
-	<string translatable="false" name="config_mainBuiltInDisplayCutout">M -186,0 L -186,94 L 186,94 L 186,0 Z</string>
+    <string translatable="false" name="config_mainBuiltInDisplayCutout">M -186,0 L -186,89 L 186,89 L 186,0 Z</string>
 </resources>

--- a/Xiaomi/MiA2Lite/res/xml/power_profile.xml
+++ b/Xiaomi/MiA2Lite/res/xml/power_profile.xml
@@ -1,23 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <device name="Android">
-    <item name="screen.on">63</item>
-    <item name="screen.full">261</item>
+    <item name="screen.on">96.02</item>
+    <item name="screen.full">347.74</item>
+    <item name="bluetooth.active">9.25</item>
+    <item name="bluetooth.on">1.62</item>
+    <item name="wifi.on">0.41</item>
+    <item name="wifi.active">131.28</item>
+    <item name="wifi.scan">40</item>
+    <item name="dsp.audio">28.71</item>
+    <item name="dsp.video">67.08</item>
+    <item name="camera.flashlight">160</item>
+    <item name="camera.avg">539.58</item>
+    <item name="gps.on">46.865</item>
+    <item name="radio.active">134.84</item>
+    <item name="radio.scanning">10</item>
     <array name="cpu.speeds">
-        <value>200000</value>
-        <value>499200</value>
-        <value>533333</value>
-        <value>800000</value>
-        <value>998400</value>
-        <value>1094400</value>
-        <value>1209600</value>
+        <value>518400</value>
+        <value>652800</value>
+        <value>844800</value>
+        <value>883200</value>
+        <value>1036800</value>
+        <value>1248000</value>
+        <value>1401600</value>
+        <value>1689600</value>
+        <value>1804800</value>
+        <value>1958400</value>
+        <value>2016000</value>
+        <value>2150400</value>
+        <value>2208000</value>
+        <value>2400000</value>
     </array>
     <array name="cpu.active">
+        <value>143</value>
         <value>151</value>
         <value>169</value>
+        <value>171</value>
         <value>177</value>
+        <value>188</value>
         <value>195</value>
+        <value>225</value>
         <value>259</value>
+        <value>292</value>
         <value>307</value>
+        <value>321</value>
+        <value>337</value>
         <value>353</value>
     </array>
     <item name="cpu.awake">1.6</item>


### PR DESCRIPTION
  * taked power values from 'sakura'
    (now power statistics works for more apps)
  * additional cpu freqs support for custom kernels
  * added measured values for notch
    (now it looks much better, height of statusbar equal notch height)

	modified:   Xiaomi/MiA2Lite/res/values-land/notch.xml
	modified:   Xiaomi/MiA2Lite/res/values/config.xml
	modified:   Xiaomi/MiA2Lite/res/values/notch.xml
	modified:   Xiaomi/MiA2Lite/res/xml/power_profile.xml