### PR TITLE
WIP: Xiaomi Mi A3 preliminary support for auto brightness, power profile and notch…

### DIFF
--- a/Xiaomi/MiA3/Android.mk
+++ b/Xiaomi/MiA3/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-mia3
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/MiA3/AndroidManifest.xml
+++ b/Xiaomi/MiA3/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.mia3"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*iaomi/laurel_sprout*"
+		android:priority="69"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/MiA3/res/values/config.xml
+++ b/Xiaomi/MiA3/res/values/config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessDisplayValuesNits">
+        <item>4</item>
+        <item>87</item>
+        <item>165</item>
+        <item>285</item>
+        <item>432</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>100</item>
+        <item>400</item>
+        <item>2000</item>
+        <item>10000</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessBacklight">
+        <item>1</item>
+        <item>72</item>
+        <item>88</item>
+        <item>178</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessNits">
+        <item>4</item>
+        <item>87</item>
+        <item>165</item>
+        <item>285</item>
+        <item>432</item>
+    </integer-array>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">20.000004%</fraction>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">10</integer>
+    <integer name="config_screenBrightnessDoze">1</integer>
+    <integer name="config_screenBrightnessSettingDefault">102</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
+    <integer name="config_shutdownBatteryTemperature">600</integer>
+</resources>

--- a/Xiaomi/MiA3/res/values/notch.xml
+++ b/Xiaomi/MiA3/res/values/notch.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">35.0dip</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">28.0dip</dimen>
+    <string translatable="false" name="config_mainBuiltInDisplayCutout">M-89.6,0 C-65.1346648,0 -51.1690203,0.18 -36.9506892,31.2970381 C-29.2758076,44.1422902 -15.4572493,53 0.0018857203,53 C15.4610208,53 29.2758076,44.1422902 36.9544607,31.2970381 C51.1690203,0.18 65.1384363,0 89.6,0 L-89.6,0 Z</string>
+</resources>

--- a/Xiaomi/MiA3/res/xml/power_profile.xml
+++ b/Xiaomi/MiA3/res/xml/power_profile.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="ambient.on">113.39</item>
+    <item name="screen.on">83.55</item>
+    <item name="screen.full">47.88</item>
+    <item name="bluetooth.active">10.55</item>
+    <item name="bluetooth.on">1.8</item>
+    <item name="wifi.on">1</item>
+    <item name="wifi.active">180</item>
+    <item name="wifi.scan">36</item>
+    <item name="audio">15</item>
+    <item name="video">16</item>
+    <item name="camera.flashlight">340</item>
+    <item name="camera.avg">500</item>
+    <item name="gps.on">57</item>
+    <item name="radio.active">146</item>
+    <item name="radio.scanning">1.81</item>
+    <array name="radio.on">
+        <value>1.97</value>
+        <value>1.43</value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>300000</value>
+        <value>614400</value>
+        <value>864000</value>
+        <value>1017600</value>
+        <value>1305600</value>
+        <value>1420800</value>
+        <value>1612800</value>
+        <value>1804800</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>300000</value>
+        <value>652800</value>
+        <value>902400</value>
+        <value>1056000</value>
+        <value>1401600</value>
+        <value>1536000</value>
+        <value>1804800</value>
+        <value>2016000</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>10</value>
+        <value>15</value>
+        <value>20</value>
+        <value>24</value>
+        <value>35</value>
+        <value>45</value>
+        <value>60</value>
+        <value>80</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>12</value>
+        <value>18</value>
+        <value>24</value>
+        <value>40</value>
+        <value>60</value>
+        <value>75</value>
+        <value>100</value>
+        <value>130</value>
+    </array>
+    <item name="cpu.idle">4.57</item>
+    <array name="memory.bandwidths">
+        <value>22.7</value>
+    </array>
+    <item name="battery.capacity">4030</item>
+    <item name="wifi.controller.idle">0</item>
+    <item name="wifi.controller.rx">0</item>
+    <item name="wifi.controller.tx">0</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">0</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+    <item name="modem.controller.sleep">0</item>
+    <item name="modem.controller.idle">0</item>
+    <item name="modem.controller.rx">0</item>
+    <array name="modem.controller.tx">
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+    </array>
+    <item name="modem.controller.voltage">0</item>
+    <array name="gps.signalqualitybased">
+        <value>0</value>
+        <value>0</value>
+    </array>
+    <item name="gps.voltage">0</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -68,6 +68,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-mi9se \
 	treble-overlay-xiaomi-mia2 \
 	treble-overlay-xiaomi-mia2lite \
+	treble-overlay-xiaomi-mia3 \
 	treble-overlay-xiaomi-mimax3 \
 	treble-overlay-xiaomi-mimix2s \
 	treble-overlay-xiaomi-mimix3 \


### PR DESCRIPTION
…. Bluetooth still not working
@phhusson I am working on overlays for both this device and the Redmi Note 8. Both have the Snapdragon 665 chip and with both I experience the same issue with bluetooth audio. I have tried to use a bluetooth headset for both calling and audio playback. Apart from taking long to connect to the headset and connection interrupts, I was not able to playback audio via the bluetooth device. I was however able to make a call via the headset. Do you have an idea, what the problem could be?

You can find attached a logcat [bluetooth.log](https://github.com/phhusson/vendor_hardware_overlay/files/3992381/bluetooth.log) of trying to connect to a bluetooth speaker and playing back audio. There is a prominent error at the beginning regarding missing `android.permission.BLUETOOTH` permission. I do not know how to set them. And I also tried with different music apps and the browser, all playing back the audio via the phone.

The bluetooth settings I have found in the framework-res.apk regarding bluetooth were these:
```
    <integer name="config_bluetooth_idle_cur_ma">0</integer>
    <integer name="config_bluetooth_operating_voltage_mv">0</integer>
    <integer name="config_bluetooth_rx_cur_ma">0</integer>
    <integer name="config_bluetooth_tx_cur_ma">0</integer>
```
But they change nothing regarding the behaviour and don't seem to be correct either.