### PR TITLE
Remove M40 compatibility from A60 overlay

### DIFF
--- a/Samsung/a60q/AndroidManifest.xml
+++ b/Samsung/a60q/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-                android:requiredSystemPropertyValue="+*amsung/{a60q,m40}*"
+                android:requiredSystemPropertyValue="+*amsung/a60q*"
 		android:priority="120"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
I reckon M40 users interested in running GSIs should make a separate copy themselves (and use their own power_profile if it differs).