### PR TITLE
Add overlay for Motorola Moto G7 Play (channel)

### DIFF
--- a/Moto/G7Play/Android.mk
+++ b/Moto/G7Play/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-moto-g7play
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Moto/G7Play/AndroidManifest.xml
+++ b/Moto/G7Play/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.moto.g7play"
+        android:versionCode="1"
+        android:versionName="1.0">
+
+        <!--
+                TESTS: Ignore ro.vendor.product.device
+                There is no vendor fingerprint
+        -->
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.product.device"
+                android:requiredSystemPropertyValue="channel"
+		android:priority="72"
+		android:isStatic="true" />
+</manifest>

--- a/Moto/G7Play/res/values/config.xml
+++ b/Moto/G7Play/res/values/config.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_auto_attach_data_on_creation">false</bool>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+    <bool name="config_cellBroadcastAppLinks">true</bool>
+    <bool name="config_displayBlanksAfterDoze">true</bool>
+    <bool name="config_dozeAfterScreenOffByDefault">true</bool>
+    <bool name="config_dynamic_bind_ims">true</bool>
+    <bool name="config_enableAutoPowerModes">true</bool>
+    <bool name="config_enableMultiUserUI">true</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_speed_up_audio_on_mt_calls">true</bool>
+    <bool name="config_supportSystemNavigationKeys">true</bool>
+    <bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="config_use_sim_language_file">true</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">true</bool>
+    <bool name="config_wifi_dual_band_support">false</bool>
+    <bool name="config_wifi_enable_disconnection_debounce">true</bool>
+    <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_enableNetworkLocationOverlay">false</bool>
+    <dimen name="status_bar_height_portrait">72px</dimen>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoPowerModeAnyMotionSensor">30</integer>
+    <integer name="config_bluetooth_idle_cur_ma">0</integer>
+    <integer name="config_bluetooth_operating_voltage_mv">3300</integer>
+    <integer name="config_cameraLaunchGestureSensorType">65540</integer>
+    <integer name="config_mobile_mtu">1410</integer>
+    <integer name="config_multiuserMaximumUsers">4</integer>
+    <integer name="config_screenBrightnessDark">3</integer>
+    <integer name="config_screenBrightnessDim">3</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessSettingMinimum">3</integer>
+    <integer name="config_shutdownBatteryTemperature">670</integer>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>10</item>
+        <item>20</item>
+        <item>40</item>
+        <item>70</item>
+        <item>110</item>
+        <item>160</item>
+        <item>200</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>2</item>
+        <item>10</item>
+        <item>50</item>
+        <item>90</item>
+        <item>100</item>
+        <item>150</item>
+        <item>200</item>
+        <item>300</item>
+        <item>400</item>
+        <item>500</item>
+        <item>800</item>
+        <item>1000</item>
+        <item>1300</item>
+        <item>2000</item>
+        <item>3000</item>
+        <item>4000</item>
+        <item>8000</item>
+        <item>10000</item>
+    </integer-array>
+    <integer-array name="config_keyboardTapVibePattern">
+        <item>0</item>
+        <item>20</item>
+    </integer-array>
+    <integer-array name="config_longPressVibePattern">
+        <item>0</item>
+        <item>20</item>
+    </integer-array>
+    <integer-array name="config_tether_upstream_types">
+        <item>0</item>
+        <item>1</item>
+        <item>5</item>
+        <item>7</item>
+    </integer-array>
+    <integer-array name="config_virtualKeyVibePattern">
+        <item>0</item>
+        <item>26</item>
+    </integer-array>
+    <string name="config_cameraLaunchGestureSensorStringType">com.motorola.sensor.camera_activate</string>
+    <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
+    <string name="config_ims_package">org.codeaurora.ims</string>
+    <string name="config_mainBuiltInDisplayCutout">M -188,0 L -188,72 L 188,72 L 188,0 Z</string>
+    <string-array name="config_gpsParameters">
+        <item>XTRA_SERVER_1=https://xtrapath1.izatcloud.net/xtra3grc.bin</item>
+        <item>XTRA_SERVER_2=https://xtrapath2.izatcloud.net/xtra3grc.bin</item>
+        <item>XTRA_SERVER_3=https://xtrapath3.izatcloud.net/xtra3grc.bin</item>
+        <item>NTP_SERVER=north-america.pool.ntp.org</item>
+        <item>SUPL_MODE=0</item>
+        <item>SUPL_HOST=NONE</item>
+        <item>SUPL_PORT=7275</item>
+        <item>SUPL_VER=0x20000</item>
+        <item>LPP_PROFILE=3</item>
+        <item>NMEA_PROVIDER=0</item>
+        <item>A_GLONASS_POS_PROTOCOL_SELECT=0</item>
+        <item>ERR_ESTIMATE=0</item>
+        <item>INTERMEDIATE_POS=0</item>
+        <item>SUPL_ES=1</item>
+        <item>GPS_LOCK=1</item>
+    </string-array>
+    <string-array name="config_tether_bluetooth_regexs">
+        <item>bnep\\d</item>
+        <item>bt-pan</item>
+    </string-array>
+    <string-array name="config_tether_usb_regexs">
+        <item>rndis\\d</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>wigig0</item>
+        <item>wlan0</item>
+        <item>softap0</item>
+    </string-array>
+    <string-array name="networkAttributes">
+        <item>wifi,1,1,1,-1,true</item>
+        <item>mobile,0,0,0,-1,true</item>
+        <item>mobile_mms,2,0,4,60000,true</item>
+        <item>mobile_supl,3,0,2,60000,true</item>
+        <item>mobile_dun,4,0,2,60000,true</item>
+        <item>mobile_hipri,5,0,3,60000,true</item>
+        <item>mobile_fota,10,0,2,60000,true</item>
+        <item>mobile_ims,11,0,2,60000,true</item>
+        <item>mobile_cbs,12,0,2,60000,true</item>
+        <item>bluetooth,7,7,2,-1,true</item>
+        <item>ethernet,9,9,3,-1,true</item>
+        <item>mobile_emergency,15,0,5,-1,true</item>
+    </string-array>
+    <string-array name="radioAttributes">
+        <item>1,1</item>
+        <item>0,1</item>
+        <item>7,1</item>
+        <item>9,1</item>
+    </string-array>
+</resources>

--- a/Moto/G7Play/res/xml/power_profile.xml
+++ b/Moto/G7Play/res/xml/power_profile.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">101.431</item>
+    <item name="screen.full">275.550</item>
+    <item name="wifi.on">0.606</item>
+    <item name="wifi.active">74.462</item>
+    <item name="wifi.scan">25.088</item>
+    <item name="camera.avg">374.399</item>
+    <item name="camera.flashlight">265.769</item>
+    <item name="gps.on">21.412</item>
+    <item name="radio.active">208.332</item>
+    <item name="radio.scanning">46.310</item>
+    <array name="radio.on">
+        <value>33.079</value>
+        <value>30</value>
+        <value>25</value>
+        <value>20</value>
+        <value>15</value>
+        <value>10</value>
+        <value>5</value>
+        <value>1.090</value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>614400</value>
+        <value>883200</value>
+        <value>1036800</value>
+        <value>1363200</value>
+        <value>1536000</value>
+        <value>1670400</value>
+        <value>1804800</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>633600</value>
+        <value>902400</value>
+        <value>1094400</value>
+        <value>1401600</value>
+        <value>1555200</value>
+        <value>1804800</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>8.24</value>
+        <value>18.66</value>
+        <value>20.2</value>
+        <value>28.57</value>
+        <value>48.57</value>
+        <value>51.23</value>
+        <value>62.6</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>10.85</value>
+        <value>20.85</value>
+        <value>31.57</value>
+        <value>50.96</value>
+        <value>70.31</value>
+        <value>100.25</value>
+    </array>
+    <item name="cpu.cluster_power.cluster0">4.27</item>
+    <item name="cpu.cluster_power.cluster1">7.22</item>
+    <item name="cpu.suspend">3.993</item>
+    <item name="cpu.idle">2.969</item>
+    <item name="cpu.active">3.5</item>
+    <item name="battery.capacity">3000</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -43,6 +43,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-moto-g6 \
 	treble-overlay-moto-g6play \
 	treble-overlay-moto-g6plus \
+	treble-overlay-moto-g7play \
 	treble-overlay-moto-g7power \
 	treble-overlay-nokia-b2n \
 	treble-overlay-nokia-ctl \


### PR DESCRIPTION
This adds a hardware overlay for the Motorola Moto G7 Play. The
property values are taken directly from stock ROM. Properties which
matched the AOSP default values got removed, as well as some brightness
related properties which caused problems.

The `config_wifi_dual_band_support` and `status_bar_height_portrait`
properties got added to fix the supported wifi bands and set
the status bar to the height of the notch.

In `config_gpsParameters` the `XTRA_SERVER` properties got adjusted to
use Xtra3 instead of Xtra2 files.

The overlay works fine and has been tested on a device for over a week
now without any overlay related issues so far.

Known issues for this device so far are:

- Enrolling fingerprints is not working (tracked in https://github.com/phhusson/treble_experimentations/issues/1072)
- Bluetooth audio requires disabling audio effects (tracked in https://github.com/phhusson/treble_experimentations/issues/857)
- GPS fix slow and a bit picky (I'm still looking into this)
- Automatic brightness adjustments not working (as mentioned above the
  brightness related settings caused some problems, I hope the upcoming stock
  Android 10 update will clear some things up there)

Aside from these issues everything works fine.

I plan to add a wiki page for the device soon as well.

@phhusson: As just discussed I'm not sure if all of the properties are hardware related. I'd appreciate if you could comment on the properties which aren't, so I can remove them before we move on with this PR.