### PR TITLE
Fix rounded corner radius for Redmi 7a

### DIFF
--- a/Xiaomi/Redmi7A/res/values/config.xml
+++ b/Xiaomi/Redmi7A/res/values/config.xml
@@ -90,4 +90,6 @@
     <integer name="config_bluetooth_tx_cur_ma">0</integer>
     <integer name="config_shutdownBatteryTemperature">600</integer>
     <dimen name="rounded_corner_radius">0px</dimen>
+    <dimen name="rounded_corner_radius_top">20px</dimen>
+    <dimen name="rounded_corner_radius_bottom">20px</dimen>
 </resources>


### PR DESCRIPTION
Without the properties `rounded_corner_radius_top` and `rounded_corner_radius_bottom`, the device defaults to a corner radius of ~108px, which isn't correct. I have tested it on the device