### PR TITLE
Updated overlay for Galaxy A30

### DIFF
--- a/Samsung/A30/res/values/arrays.xml
+++ b/Samsung/A30/res/values/arrays.xml
@@ -329,7 +329,6 @@
         <item>253</item>
         <item>254</item>
         <item>255</item>
-        <item>365</item>
     </integer-array>
     <integer-array name="config_screenBrightnessNits">
         <item>2</item>

--- a/Samsung/A30/res/values/arrays.xml
+++ b/Samsung/A30/res/values/arrays.xml
@@ -587,7 +587,6 @@
         <item>417</item>
         <item>419</item>
         <item>420</item>
-        <item>600</item>
     </integer-array>
     <string-array name="config_tether_usb_regexs">
         <item>rndis0</item>


### PR DESCRIPTION
This removes two lines in `arrays.xml`. Both causes the system to throw an error and not let the system boot.