### PR TITLE
Remove device specific IMS settings

### DIFF
--- a/Huawei/kirin970/BKL/res/values/values.xml
+++ b/Huawei/kirin970/BKL/res/values/values.xml
@@ -22,7 +22,6 @@
     <bool name="config_device_vt_available">true</bool>
     <bool name="config_device_wfc_ims_available">true</bool>
     <bool name="config_dynamic_bind_ims">true</bool>
-    <string name="config_ims_package">com.huawei.ims</string>
     <integer name="config_mobile_mtu">1400</integer>
     <integer name="config_screenBrightnessDark">4</integer>
     <integer name="config_screenBrightnessDim">6</integer>

--- a/Moto/G7Play/res/values/config.xml
+++ b/Moto/G7Play/res/values/config.xml
@@ -5,7 +5,6 @@
     <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
     <bool name="config_displayBlanksAfterDoze">true</bool>
     <bool name="config_dozeAfterScreenOffByDefault">true</bool>
-    <bool name="config_dynamic_bind_ims">true</bool>
     <bool name="config_hotswapCapable">true</bool>
     <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
     <bool name="config_setColorTransformAccelerated">true</bool>
@@ -85,7 +84,6 @@
         <item>26</item>
     </integer-array>
     <string name="config_cameraLaunchGestureSensorStringType">com.motorola.sensor.camera_activate</string>
-    <string name="config_ims_package">org.codeaurora.ims</string>
     <string name="config_mainBuiltInDisplayCutout">M -188,0 L -188,72 L 188,72 L 188,0 Z</string>
     <string-array name="config_gpsParameters">
         <item>XTRA_SERVER_1=https://xtrapath1.izatcloud.net/xtra3grc.bin</item>

--- a/Xiaomi/RedmiGo/res/values/config.xml
+++ b/Xiaomi/RedmiGo/res/values/config.xml
@@ -181,23 +181,10 @@
     <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
     <!-- Flag indicating if the speed up audio on mt call code should be executed -->
     <bool name="config_speed_up_audio_on_mt_calls">true</bool>
-    <!-- Flag specifying whether VoLTE is available on device -->
-    <bool name="config_device_volte_available">true</bool>
-    <!-- Flag specifying whether VoLTE should be available for carrier: independent of
-         carrier provisioning. If false: hard disabled. If true: then depends on carrier
-         provisioning, availability etc -->
-    <bool name="config_carrier_volte_available">true</bool>
     <!-- Flag specifying whether VT should be available for carrier: independent of
          carrier provisioning. If false: hard disabled. If true: then depends on carrier
          provisioning, availability etc -->
     <bool name="config_device_vt_available">true</bool>
-    <!-- Flag specifying whether WFC over IMS is available on device -->
-    <bool name="config_device_wfc_ims_available">true</bool>
-    <!-- ImsService package name to bind to by default. If none is specified in an overlay, an
-         empty string is passed in -->
-    <string name="config_ims_package">org.codeaurora.ims</string>
-    <!-- Flag specifying whether or not IMS will use the dynamic ImsResolver -->
-    <bool name="config_dynamic_bind_ims">true</bool>
     <!-- Config determines whether to update phone object when voice registration
          state changes. Voice radio tech change will always trigger an update of
          phone object irrespective of this config -->


### PR DESCRIPTION
This removes all device specific IMS settings, which are already set by the *-IMS overlays.

As a result `config_ims_package` could be added to the blacklist of keys, if it wouldn't be used in the *-IMS overlays.