### PR TITLE
Remove redundant tethering settings

### DIFF
--- a/Huawei/hi3660/DUK/res/values/config.xml
+++ b/Huawei/hi3660/DUK/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi3660/STF/res/values/config.xml
+++ b/Huawei/hi3660/STF/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi3660/VTR/res/values/config.xml
+++ b/Huawei/hi3660/VTR/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi6250/ANE/res/values/config.xml
+++ b/Huawei/hi6250/ANE/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi6250/BND/res/values/config.xml
+++ b/Huawei/hi6250/BND/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi6250/LLD/res/values/config.xml
+++ b/Huawei/hi6250/LLD/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi6250/PRA/res/values/config.xml
+++ b/Huawei/hi6250/PRA/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi6250/RNE/res/values/config.xml
+++ b/Huawei/hi6250/RNE/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/hi6250/WAS/res/values/config.xml
+++ b/Huawei/hi6250/WAS/res/values/config.xml
@@ -135,29 +135,6 @@
     <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
     <bool name="config_intrusiveNotificationLed">true</bool>
 
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tething over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>"usb\\d"</item>
-        <item>"rndis\\d"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>"wlan0"</item>
-        <item>"softap.*"</item>
-    </string-array>
-
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-         should be empty. -->
-    <string-array translatable="false" name="config_tether_bluetooth_regexs">
-        <item>"bt-pan"</item>
-    </string-array>
-
     <!-- Array of allowable ConnectivityManager network types for tethering -->
     <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/msm8917/ATU/res/values/config.xml
+++ b/Huawei/msm8917/ATU/res/values/config.xml
@@ -156,29 +156,6 @@
 	<!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
 	<bool name="config_intrusiveNotificationLed">true</bool>
 
-	<!-- List of regexpressions describing the interface (if any) that represent tetherable
-	USB interfaces.  If the device doesn't want to support tething over USB this should
-	be empty.  An example would be "usb.*" -->
-	<string-array translatable="false" name="config_tether_usb_regexs">
-		<item>"usb\\d"</item>
-		<item>"rndis\\d"</item>
-	</string-array>
-
-	<!-- List of regexpressions describing the interface (if any) that represent tetherable
-	Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-	should be empty.  An example would be "softap.*" -->
-	<string-array translatable="false" name="config_tether_wifi_regexs">
-		<item>"wlan0"</item>
-		<item>"softap.*"</item>
-	</string-array>
-
-	<!-- List of regexpressions describing the interface (if any) that represent tetherable
-	bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
-	should be empty. -->
-	<string-array translatable="false" name="config_tether_bluetooth_regexs">
-		<item>"bt-pan"</item>
-	</string-array>
-
 	<!-- Array of allowable ConnectivityManager network types for tethering -->
 	<!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
 	[0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->

--- a/Huawei/msm8937/AUM/res/values/arrays.xml
+++ b/Huawei/msm8937/AUM/res/values/arrays.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-        <string-array name="config_tether_bluetooth_regexs">
-        <item>bt-pan</item>
-    </string-array>
     <string-array name="networkAttributes">
         <item>wifi,1,1,1,-1,true</item>
         <item>mobile,0,0,0,-1,true</item>

--- a/Infinix/Note5/res/values/config.xml
+++ b/Infinix/Note5/res/values/config.xml
@@ -99,9 +99,6 @@
         <item>mobile_vsim,28,0,-1,60000,true</item>
         <item>mobile_preempt,29,0,9,60000,true</item>
     </string-array>
-    <string-array name="config_tether_usb_regexs">
-        <item>rndis\\d</item>
-    </string-array>
     <string-array name="config_tether_wifi_regexs">
         <item>ap\\d</item>
     </string-array>

--- a/Infinix/S4/res/values/config.xml
+++ b/Infinix/S4/res/values/config.xml
@@ -59,9 +59,6 @@
         <item>255</item>
         <item>255</item>
     </integer-array>
-    <string-array name="config_tether_usb_regexs">
-        <item>rndis\\d</item>
-    </string-array>
     <string-array name="config_tether_wifi_regexs">
         <item>ap\\d</item>
     </string-array>

--- a/Moto/G7Play/res/values/config.xml
+++ b/Moto/G7Play/res/values/config.xml
@@ -102,18 +102,6 @@
         <item>SUPL_ES=1</item>
         <item>GPS_LOCK=1</item>
     </string-array>
-    <string-array name="config_tether_bluetooth_regexs">
-        <item>bnep\\d</item>
-        <item>bt-pan</item>
-    </string-array>
-    <string-array name="config_tether_usb_regexs">
-        <item>rndis\\d</item>
-    </string-array>
-    <string-array name="config_tether_wifi_regexs">
-        <item>wigig0</item>
-        <item>wlan0</item>
-        <item>softap0</item>
-    </string-array>
     <string-array name="networkAttributes">
         <item>wifi,1,1,1,-1,true</item>
         <item>mobile,0,0,0,-1,true</item>

--- a/Razer/cheryl/res/values/arrays.xml
+++ b/Razer/cheryl/res/values/arrays.xml
@@ -79,24 +79,12 @@
         <item>150</item>
         <item>35</item>
     </integer-array>
-    <string-array name="config_tether_bluetooth_regexs">
-        <item>bnep\\d</item>
-        <item>bt-pan</item>
-    </string-array>
     <integer-array name="config_tether_upstream_types">
         <item>1</item>
         <item>7</item>
         <item>0</item>
         <item>5</item>
     </integer-array>
-    <string-array name="config_tether_usb_regexs">
-        <item>usb\\d</item>
-        <item>rndis\\d</item>
-    </string-array>
-    <string-array name="config_tether_wifi_regexs">
-        <item>wigig0</item>
-        <item>softap0</item>
-    </string-array>
     <integer-array name="config_virtualKeyVibePattern">
         <item>0</item>
         <item>13</item>

--- a/Samsung/A30/res/values/arrays.xml
+++ b/Samsung/A30/res/values/arrays.xml
@@ -588,12 +588,6 @@
         <item>419</item>
         <item>420</item>
     </integer-array>
-    <string-array name="config_tether_usb_regexs">
-        <item>rndis0</item>
-    </string-array>
-    <string-array name="config_tether_wifi_regexs">
-        <item>wlan0</item>
-    </string-array>
     <string-array name="networkAttributes">
         <item>wifi,1,1,1,-1,true</item>
         <item>mobile,0,0,0,-1,true</item>

--- a/Samsung/S10pq/res/values/arrays.xml
+++ b/Samsung/S10pq/res/values/arrays.xml
@@ -594,11 +594,6 @@
         <item>418.4</item>
         <item>420</item>
     </array>
-    <string-array name="config_tether_wifi_regexs">
-        <item>softap0</item>
-        <item>wigig0</item>
-        <item>wifi_br0</item>
-    </string-array>
     <string-array name="config_tether_usb_regexs">
         <item>usb\\d</item>
         <item>rndis\\d</item>
@@ -631,10 +626,6 @@
         <item>1,1</item>
         <item>0,1</item>
         <item>7,1</item>
-    </string-array>
-    <string-array name="config_tether_bluetooth_regexs">
-        <item>bnep\\d</item>
-        <item>bt-pan</item>
     </string-array>
     <integer-array name="config_tether_upstream_types">
         <item>0</item>

--- a/Samsung/S10q/res/values/arrays.xml
+++ b/Samsung/S10q/res/values/arrays.xml
@@ -594,11 +594,6 @@
         <item>418.4</item>
         <item>420</item>
     </array>
-    <string-array name="config_tether_wifi_regexs">
-        <item>softap0</item>
-        <item>wigig0</item>
-        <item>wifi_br0</item>
-    </string-array>
     <string-array name="config_tether_usb_regexs">
         <item>usb\\d</item>
         <item>rndis\\d</item>
@@ -631,10 +626,6 @@
         <item>1,1</item>
         <item>0,1</item>
         <item>7,1</item>
-    </string-array>
-    <string-array name="config_tether_bluetooth_regexs">
-        <item>bnep\\d</item>
-        <item>bt-pan</item>
     </string-array>
     <integer-array name="config_tether_upstream_types">
         <item>0</item>

--- a/Tecno/Camon11/res/values/config.xml
+++ b/Tecno/Camon11/res/values/config.xml
@@ -63,9 +63,6 @@
         <item>255</item>
         <item>255</item>
     </integer-array>
-    <string-array name="config_tether_usb_regexs">
-        <item>rndis\\d</item>
-    </string-array>
     <string-array name="config_tether_wifi_regexs">
         <item>ap\\d</item>
     </string-array>

--- a/Xiaomi/RedmiGo/res/values/config.xml
+++ b/Xiaomi/RedmiGo/res/values/config.xml
@@ -17,20 +17,6 @@
 */
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         USB interfaces.  If the device doesn't want to support tethering over USB this should
-         be empty.  An example would be "usb.*" -->
-    <string-array translatable="false" name="config_tether_usb_regexs">
-        <item>usb\\d</item>
-        <item>rndis\\d</item>
-    </string-array>
-    <!-- List of regexpressions describing the interface (if any) that represent tetherable
-         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
-         should be empty.  An example would be "softap.*" -->
-    <string-array translatable="false" name="config_tether_wifi_regexs">
-        <item>wigig0</item>
-        <item>wlan0</item>
-    </string-array>
     <!-- Array of ConnectivityManager.TYPE_xxxx values allowable for tethering.
          Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
          [1,7,0] for TYPE_WIFI, TYPE_BLUETOOTH, and TYPE_MOBILE.

--- a/bq/jeice/res/values/config.xml
+++ b/bq/jeice/res/values/config.xml
@@ -97,24 +97,12 @@
   <bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
   <bool name="config_sustainedPerformanceModeSupported">false</bool>
   <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
-  <string-array name="config_tether_bluetooth_regexs">
-    <item>bnep\d</item>
-    <item>bt-pan</item>
-  </string-array>
   <integer-array name="config_tether_upstream_types">
     <item>0</item>
     <item>1</item>
     <item>5</item>
     <item>7</item>
   </integer-array>
-  <string-array name="config_tether_usb_regexs">
-    <item>usb\d</item>
-    <item>rndis\d</item>
-  </string-array>
-  <string-array name="config_tether_wifi_regexs">
-    <item>wigig0</item>
-    <item>wlan0</item>
-  </string-array>
   <bool name="config_useDevInputEventForAudioJack">true</bool>
   <bool name="config_use_sim_language_file">false</bool>
   <integer-array name="config_virtualKeyVibePattern">


### PR DESCRIPTION
Remove all config properties for tethering settings which are equal or a
subset of the [values already set for the GSI][1]. This should be safe
to do, as the worst thing which might happen is that devices consider
interfaces for tethering which aren't meant for tethering.

There are a few devices left, which define interfaces for tethering,
which aren't already defined by the GSI. I'm not sure if these
interfaces are relevant. If not, we could simply remove the tethering
properties for these devices as well and blacklist them.

The devices in question are:

| device | property | value not defined by GSI |
| ------ | -------- | ------------------------ |
| Infinix Note5 | `config_tether_bluetooth_regexs` | `bt-dun` |
| Infinix S4 | `config_tether_bluetooth_regexs` | `bt-dun` |
| Techno Camon11 | `config_tether_bluetooth_regexs` | `bt-dun` |
| Samsung A50 | `config_tether_usb_regexs` | `ncm\\d` |
| Samsung S10pq | `config_tether_usb_regexs` | `ncm\\d` |
| Samsung S10q | `config_tether_usb_regexs` | `ncm\\d` |
| Infinix Note5 | `config_tether_wifi_regexs` | `ap\\d` |
| Infinix S4 | `config_tether_wifi_regexs` | `ap\\d` |
| Tecno Camon11 | `config_tether_wifi_regexs` | `ap\\d` |


[1]: https://github.com/phhusson/device_phh_treble/blob/04583fa95a6c58d25dda7644002f9da05eee3ab2/overlay/frameworks/base/core/res/res/values/config.xml#L3-L18