### PR TITLE
Add overlay for HTC U11+

### DIFF
--- a/HTC/U11Plus/Android.mk
+++ b/HTC/U11Plus/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-htc-u11plus
+LOCAL_MODULE_PATH := $(TARGET_OUT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/HTC/U11Plus/AndroidManifest.xml
+++ b/HTC/U11Plus/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.htc.u11plus"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+		android:requiredSystemPropertyValue="+htc/ocmdugl_00709*"
+		android:priority="135"
+		android:isStatic="true" />
+</manifest>

--- a/HTC/U11Plus/res/values/config.xml
+++ b/HTC/U11Plus/res/values/config.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate. -->
+<resources>
+    <!-- Flag indicating whether the we should enable the automatic brightness in Settings.
+         Software implementation will be used if config_hardware_auto_brightness_available is not set -->
+    <bool name="config_automatic_brightness_available">true</bool>
+
+    <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
+         The N entries of this array define N  1 zones as follows:
+
+         Zone 0:        0 <= LUX < array[0]
+         Zone 1:        array[0] <= LUX < array[1]
+         ...
+         Zone N:        array[N - 1] <= LUX < array[N]
+         Zone N + 1     array[N] <= LUX < infinity
+
+         Must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>5</item>
+        <item>15</item>
+        <item>16</item>
+        <item>74</item>
+        <item>75</item>
+        <item>149</item>
+        <item>150</item>
+        <item>1500</item>
+        <item>3500</item>
+        <item>5000</item>
+        <item>6500</item>
+        <item>12000</item>
+        <item>15000</item>
+    </integer-array>
+
+    <!-- Array of output values for LCD backlight corresponding to the LUX values
+         in the config_autoBrightnessLevels array.  This array should have size one greater
+         than the size of the config_autoBrightnessLevels array.
+         This must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>33</item>
+        <item>42</item>
+        <item>75</item>
+        <item>75</item>
+        <item>104</item>
+        <item>104</item>
+        <item>123</item>
+        <item>123</item>
+        <item>142</item>
+        <item>154</item>
+        <item>214</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+        <item>255</item>
+    </integer-array>
+
+    <!-- Screen brightness used to dim the screen when the user activity
+         timeout expires.  May be less than the minimum allowed brightness setting
+         that can be set by the user. -->
+    <integer name="config_screenBrightnessDim">10</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+
+    <!-- Default screen brightness setting.
+         Must be in the range specified by minimum and maximum. -->
+    <integer name="config_screenBrightnessSettingDefault">102</integer>
+
+    <!-- Minimum screen brightness setting allowed by the power manager.
+         The user is forbidden from setting the brightness below this level. -->
+      <integer name="config_screenBrightnessSettingMinimum">10</integer>
+
+    <!-- Stability requirements in milliseconds for accepting a new brightness level.  This is used
+         for debouncing the light sensor.  Different constants are used to debounce the light sensor
+         when adapting to brighter or darker environments.  This parameter controls how quickly
+         brightness changes occur in response to an observed change in light level that exceeds the
+         hysteresis threshold. -->
+    <integer name="config_autoBrightnessBrighteningLightDebounce">4000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">8000</integer>
+     <!-- The maximum range of gamma adjustment possible using the screen
+         auto-brightness adjustment setting. -->
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">300%</fraction>
+ 
+    <!-- Period of time in which to consider light samples in milliseconds. -->
+	
+    <!-- Amount of time it takes for the light sensor to warm up in milliseconds.
+         For this time after the screen turns on, the Power Manager
+         will not debounce light sensor readings -->
+    <integer name="config_lightSensorWarmupTime">0</integer>
+
+    <!-- The bounding path of the cutout region of the main built-in display.
+         Must either be empty if there is no cutout region, or a string that is parsable by
+         {@link android.util.PathParser}.
+
+         The path is assumed to be specified in display coordinates with pixel units and in
+         the display's native orientation, with the origin of the coordinate system at the
+         center top of the display.
+
+         To facilitate writing device-independent emulation overlays, the marker `@dp` can be
+         appended after the path string to interpret coordinates in dp instead of px units.
+         Note that a physical cutout should be configured in pixels for the best results.
+         -->
+
+       <!-- Height of the status bar -->
+          
+    <!-- Screen off delay
+    <integer name="config_screen_off_delay">1800</integer> -->
+    <!-- Radius of the software rounded corners. 
+    <dimen name="rounded_corner_radius">48px</dimen>-->
+
+</resources>

--- a/HTC/U11Plus/res/xml/power_profile.xml
+++ b/HTC/U11Plus/res/xml/power_profile.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">105.42</item>
+    <item name="screen.full">388.89</item>
+    <array name="screen.brightness">
+        <value>dark</value>
+        <value>dim</value>
+        <value>medium</value>
+        <value>light</value>
+        <value>bright</value>
+    </array>
+    <array name="screen.brightness_bin">
+        <value>0</value>
+        <value>24.56</value>
+        <value>96.03</value>
+        <value>186.37</value>
+        <value>276.7</value>
+    </array>
+    <array name="gpu.speeds">
+        <value>190000</value>
+        <value>305000</value>
+        <value>390000</value>
+        <value>450000</value>
+        <value>510000</value>
+        <value>600000</value>
+    </array>
+    <array name="gpu.active">
+        <value>104.95</value>
+        <value>341.61</value>
+        <value>516.54</value>
+        <value>640.01</value>
+        <value>763.49</value>
+        <value>948.71</value>
+    </array>
+    <item name="bluetooth.active">58.83</item>
+    <item name="bluetooth.on">13.96</item>
+    <item name="bluetooth.at">0</item>
+    <item name="wifi.on">0.83</item>
+    <item name="wifi.active">105.42</item>
+    <item name="wifi.scan">83.3</item>
+    <item name="dsp.audio">229.71</item>
+    <item name="dsp.video">368.91</item>
+    <item name="radio.talk">150.81</item>
+    <item name="radio.active">205</item>
+    <item name="gps.on">58</item>
+    <item name="radio.scanning">36.5</item>
+    <item name="camera.flashlight">1000</item>
+    <item name="camera.avg">1400</item>
+    <array name="radio.on">
+        <value>36.5</value>
+        <value>36.5</value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>300000</value>
+        <value>364800</value>
+        <value>441600</value>
+        <value>518400</value>
+        <value>595200</value>
+        <value>672000</value>
+        <value>748800</value>
+        <value>825600</value>
+        <value>883200</value>
+        <value>960000</value>
+        <value>1036800</value>
+        <value>1094400</value>
+        <value>1171200</value>
+        <value>1248000</value>
+        <value>1324800</value>
+        <value>1401600</value>
+        <value>1478400</value>
+        <value>1555200</value>
+        <value>1670400</value>
+        <value>1747200</value>
+        <value>1824000</value>
+        <value>1900800</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>86.34</value>
+        <value>87.03</value>
+        <value>87.53</value>
+        <value>88.59</value>
+        <value>89.78</value>
+        <value>90.36</value>
+        <value>90.09</value>
+        <value>90.4</value>
+        <value>91.67</value>
+        <value>93.13</value>
+        <value>93.32</value>
+        <value>95.71</value>
+        <value>97.32</value>
+        <value>98.23</value>
+        <value>99.77</value>
+        <value>100.65</value>
+        <value>102.48</value>
+        <value>104.21</value>
+        <value>108.1</value>
+        <value>108.97</value>
+        <value>112.54</value>
+        <value>116.01</value>
+    </array>
+    <array name="cpu.speeds.cluster1">
+        <value>300000</value>
+        <value>345600</value>
+        <value>422400</value>
+        <value>499200</value>
+        <value>576000</value>
+        <value>652800</value>
+        <value>729600</value>
+        <value>806400</value>
+        <value>902400</value>
+        <value>979200</value>
+        <value>1056000</value>
+        <value>1132800</value>
+        <value>1190400</value>
+        <value>1267200</value>
+        <value>1344000</value>
+        <value>1420800</value>
+        <value>1497600</value>
+        <value>1574400</value>
+        <value>1651200</value>
+        <value>1728000</value>
+        <value>1804800</value>
+        <value>1881600</value>
+        <value>1958400</value>
+        <value>2035200</value>
+        <value>2112000</value>
+        <value>2208000</value>
+        <value>2265600</value>
+        <value>2323200</value>
+        <value>2342400</value>
+        <value>2361600</value>
+        <value>2457600</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>72.87</value>
+        <value>73.39</value>
+        <value>74.36</value>
+        <value>76.07</value>
+        <value>77.37</value>
+        <value>78.27</value>
+        <value>79.42</value>
+        <value>78.92</value>
+        <value>78.22</value>
+        <value>77.57</value>
+        <value>84.11</value>
+        <value>86.39</value>
+        <value>88.99</value>
+        <value>91.18</value>
+        <value>93.23</value>
+        <value>95.72</value>
+        <value>98.78</value>
+        <value>101.92</value>
+        <value>105.35</value>
+        <value>109.26</value>
+        <value>115.13</value>
+        <value>115.62</value>
+        <value>126.26</value>
+        <value>130.42</value>
+        <value>137.85</value>
+        <value>166.49</value>
+        <value>174.81</value>
+        <value>182.61</value>
+        <value>185.49</value>
+        <value>187.88</value>
+        <value>187.07</value>
+    </array>
+    <item name="cpu.idle">5.07</item>
+    <item name="cpu.awake">18.93</item>
+    <item name="battery.capacity">3930</item>
+    <array name="wifi.batchedscan">
+        <value>0.0002</value>
+        <value>0.002</value>
+        <value>0.02</value>
+        <value>0.2</value>
+        <value>2</value>
+    </array>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -15,6 +15,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-devinputjack \
 	treble-overlay-essential-ph_1 \
 	treble-overlay-htc-exodus1 \
+	treble-overlay-htc-u11plus \
 	treble-overlay-htc-u12plus \
 	treble-overlay-huawei \
 	treble-overlay-huawei-ANE \


### PR DESCRIPTION
This overlay fixes auto brightness, minimal brightness, night light and battery estimates.
Tested on my U11+ with Havoc-OS 3.5 (Android 10).
I made it based on HTC's stock rom.