### PR TITLE
Moto G7 Play stock Android 10 updates

### DIFF
--- a/Moto/G7Play/res/values/config.xml
+++ b/Moto/G7Play/res/values/config.xml
@@ -1,10 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="config_auto_attach_data_on_creation">false</bool>
-    <bool name="config_automatic_brightness_available">true</bool>
-    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
     <bool name="config_displayBlanksAfterDoze">true</bool>
     <bool name="config_dozeAfterScreenOffByDefault">true</bool>
+    <bool name="config_use_sim_language_file">true</bool>
+    <bool name="config_wifi_dual_band_support">false</bool>
+    <bool name="config_wifi_enable_disconnection_debounce">true</bool>
+    <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
+    <dimen name="status_bar_height_portrait">72px</dimen>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoPowerModeAnyMotionSensor">30</integer>
+    <integer name="config_mobile_mtu">1410</integer>
+    <string-array name="config_gpsParameters">
+        <item>XTRA_SERVER_1=https://xtrapath1.izatcloud.net/xtra3grc.bin</item>
+        <item>XTRA_SERVER_2=https://xtrapath2.izatcloud.net/xtra3grc.bin</item>
+        <item>XTRA_SERVER_3=https://xtrapath3.izatcloud.net/xtra3grc.bin</item>
+        <item>NTP_SERVER=north-america.pool.ntp.org</item>
+        <item>SUPL_MODE=0</item>
+        <item>SUPL_HOST=NONE</item>
+        <item>SUPL_PORT=7275</item>
+        <item>SUPL_VER=0x20000</item>
+        <item>LPP_PROFILE=3</item>
+        <item>NMEA_PROVIDER=0</item>
+        <item>A_GLONASS_POS_PROTOCOL_SELECT=0</item>
+        <item>ERR_ESTIMATE=0</item>
+        <item>INTERMEDIATE_POS=0</item>
+        <item>SUPL_ES=1</item>
+        <item>GPS_LOCK=1</item>
+    </string-array>
+
+    <!-- The properties below are only in here to keep compatibility with
+         devices which weren't updated to Motorola's stock Android 10 ROM
+         before flashing the GSI. For devices which got Motorola's Android
+         10 ROM flashed before, these properties are provided by
+         /vendor/overlay/framework-res__auto_generated_rro_vendor.apk.
+    -->
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
     <bool name="config_hotswapCapable">true</bool>
     <bool name="config_showNavigationBar">true</bool>
     <bool name="config_speed_up_audio_on_mt_calls">true</bool>
@@ -12,19 +44,11 @@
     <bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
     <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
     <bool name="config_useDevInputEventForAudioJack">true</bool>
-    <bool name="config_use_sim_language_file">true</bool>
     <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
     <bool name="config_wifi_background_scan_support">true</bool>
     <bool name="config_wifi_batched_scan_supported">true</bool>
-    <bool name="config_wifi_dual_band_support">false</bool>
-    <bool name="config_wifi_enable_disconnection_debounce">true</bool>
-    <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
     <bool name="skip_restoring_network_selection">true</bool>
-    <dimen name="status_bar_height_portrait">72px</dimen>
-    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
-    <integer name="config_autoPowerModeAnyMotionSensor">30</integer>
     <integer name="config_cameraLaunchGestureSensorType">65540</integer>
-    <integer name="config_mobile_mtu">1410</integer>
     <integer name="config_screenBrightnessDark">3</integer>
     <integer name="config_screenBrightnessDim">3</integer>
     <integer name="config_screenBrightnessDoze">17</integer>
@@ -80,23 +104,6 @@
     </integer-array>
     <string name="config_cameraLaunchGestureSensorStringType">com.motorola.sensor.camera_activate</string>
     <string name="config_mainBuiltInDisplayCutout">M -188,0 L -188,72 L 188,72 L 188,0 Z</string>
-    <string-array name="config_gpsParameters">
-        <item>XTRA_SERVER_1=https://xtrapath1.izatcloud.net/xtra3grc.bin</item>
-        <item>XTRA_SERVER_2=https://xtrapath2.izatcloud.net/xtra3grc.bin</item>
-        <item>XTRA_SERVER_3=https://xtrapath3.izatcloud.net/xtra3grc.bin</item>
-        <item>NTP_SERVER=north-america.pool.ntp.org</item>
-        <item>SUPL_MODE=0</item>
-        <item>SUPL_HOST=NONE</item>
-        <item>SUPL_PORT=7275</item>
-        <item>SUPL_VER=0x20000</item>
-        <item>LPP_PROFILE=3</item>
-        <item>NMEA_PROVIDER=0</item>
-        <item>A_GLONASS_POS_PROTOCOL_SELECT=0</item>
-        <item>ERR_ESTIMATE=0</item>
-        <item>INTERMEDIATE_POS=0</item>
-        <item>SUPL_ES=1</item>
-        <item>GPS_LOCK=1</item>
-    </string-array>
     <string-array name="config_tether_bluetooth_regexs">
         <item>bnep\\d</item>
         <item>bt-pan</item>

--- a/Moto/G7Play/res/values/config.xml
+++ b/Moto/G7Play/res/values/config.xml
@@ -6,8 +6,6 @@
     <bool name="config_displayBlanksAfterDoze">true</bool>
     <bool name="config_dozeAfterScreenOffByDefault">true</bool>
     <bool name="config_hotswapCapable">true</bool>
-    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
-    <bool name="config_setColorTransformAccelerated">true</bool>
     <bool name="config_showNavigationBar">true</bool>
     <bool name="config_speed_up_audio_on_mt_calls">true</bool>
     <bool name="config_supportSystemNavigationKeys">true</bool>
@@ -22,12 +20,9 @@
     <bool name="config_wifi_enable_disconnection_debounce">true</bool>
     <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
     <bool name="skip_restoring_network_selection">true</bool>
-    <bool name="config_enableNetworkLocationOverlay">false</bool>
     <dimen name="status_bar_height_portrait">72px</dimen>
     <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
     <integer name="config_autoPowerModeAnyMotionSensor">30</integer>
-    <integer name="config_bluetooth_idle_cur_ma">0</integer>
-    <integer name="config_bluetooth_operating_voltage_mv">3300</integer>
     <integer name="config_cameraLaunchGestureSensorType">65540</integer>
     <integer name="config_mobile_mtu">1410</integer>
     <integer name="config_screenBrightnessDark">3</integer>


### PR DESCRIPTION
This PR contains changes for the overlay for the Motorola Moto G7 Play based on the contents of the stock Android 10 ROM. While it doesn't contain significant changes, it's removing some unnecessary properties and adds comments which properties are only required when using a GSI coming from an Android 9 stock image.