### PR TITLE
Samsung Galaxy A40: Overlay improvements

### DIFF
--- a/Samsung/A40/res/values/brightness.xml
+++ b/Samsung/A40/res/values/brightness.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_allowAutoBrightnessWhileDozing">true</bool>
     <integer name="config_screenBrightnessDim">15</integer>
     <integer name="config_screenBrightnessSettingDefault">128</integer>
     <integer name="config_screenBrightnessSettingMaximum">255</integer>

--- a/Samsung/A40/res/values/brightness.xml
+++ b/Samsung/A40/res/values/brightness.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="config_automatic_brightness_available">true</bool>
     <bool name="config_allowAutoBrightnessWhileDozing">true</bool>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
     <integer name="config_screenBrightnessDim">15</integer>
     <integer name="config_screenBrightnessSettingDefault">128</integer>
     <integer name="config_screenBrightnessSettingMaximum">255</integer>

--- a/Samsung/A40/res/values/config.xml
+++ b/Samsung/A40/res/values/config.xml
@@ -2,10 +2,4 @@
 <resources>
     <bool name="config_showNavigationBar">true</bool>
     <bool name="config_useDevInputEventForAudioJack">false</bool>
-    <string-array name="config_tether_usb_regexs">
-        <item>rndis0</item>
-    </string-array>
-    <string-array name="config_tether_wifi_regexs">
-        <item>wlan0</item>
-    </string-array>
 </resources>

--- a/Samsung/A40/res/values/doze.xml
+++ b/Samsung/A40/res/values/doze.xml
@@ -2,5 +2,4 @@
 <resources>
     <bool name="config_enableBurnInProtection">true</bool>
     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-    <bool name="config_dozePulsePickup">true</bool>
 </resources>

--- a/Samsung/A40/res/values/network.xml
+++ b/Samsung/A40/res/values/network.xml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
     <bool name="config_wifi_dual_band_support">true</bool>
     <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
+    <bool name="config_wifi_p2p_mac_randomization_supported">false</bool>    
     <string-array name="config_mobile_tcp_buffers">
         <item>5gnr:2097152,6291456,16777216,512000,2097152,8388608</item>
         <item>lte:2097152,4194304,8388608,1048576,3145728,4194304</item>
+    </string-array>
+    <string-array name="config_tether_usb_regexs">
+        <item>rndis0</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>wlan0</item>
     </string-array>
     <string-array name="networkAttributes">
         <item>wifi,1,1,1,-1,true</item>


### PR DESCRIPTION
- Add new random address mac support values
- Remove unsupported doze pulse pickup key
- Enable auto brightness on Doze
- Some keys were rearranged