### PR TITLE
FP3 overlay: Changed to <item>SUPL_VER=0x30000</item> instead of version 2

### DIFF
--- a/Fairphone/FP3/res/values/config.xml
+++ b/Fairphone/FP3/res/values/config.xml
@@ -450,7 +450,7 @@
         <item>NTP_SERVER=europe.pool.ntp.org</item>
         <item>#SUPL_HOST=supl.google.com</item>
         <item>#SUPL_PORT=7275</item>
-        <item>SUPL_VER=0x20000</item>
+        <item>SUPL_VER=0x30000</item>
         <item>#SUPL_MODE=1</item>
         <item>#SUPL_ES=1</item>
         <item>#LPP_PROFILE=3</item>


### PR DESCRIPTION
... because -as you said- version 2 has severe security flaws...

@phhusson: I've checked it on my FP3 and it works fine :-) Thanks again for the hint!