### PR TITLE
Add resources for ASUS Zenfone 5 (ASUS_X00QD, Q vendor)

### DIFF
--- a/Asus/Zenfone5-10/Android.mk
+++ b/Asus/Zenfone5-10/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-asus-zenfone5-10
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Asus/Zenfone5-10/AndroidManifest.xml
+++ b/Asus/Zenfone5-10/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.asus.zenfone5.ten"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.product.vendor.name"
+                android:requiredSystemPropertyValue="ASUS_X00QD"
+		android:priority="162"
+		android:isStatic="true" />
+</manifest>

--- a/Asus/Zenfone5-10/res/values/config.xml
+++ b/Asus/Zenfone5-10/res/values/config.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+
+    <dimen name="status_bar_height_portrait">87.0px</dimen>
+    <dimen name="status_bar_height_landscape">28dp</dimen>
+
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">20.000004%</fraction>
+
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">10</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
+    <integer name="config_screenBrightnessSettingDefault">46</integer>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
+    <integer name="config_brightness_ramp_rate_fast">180</integer>
+    <integer name="config_brightness_ramp_rate_slow">40</integer>
+
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>15</item>
+        <item>30</item>
+        <item>50</item>
+        <item>100</item>
+        <item>200</item>
+        <item>300</item>
+        <item>400</item>
+        <item>500</item>
+        <item>650</item>
+        <item>800</item>
+        <item>1000</item>
+        <item>1500</item>
+        <item>2000</item>
+        <item>3000</item>
+        <item>4000</item>
+        <item>5000</item>
+        <item>7000</item>
+        <item>10000</item>
+        <item>12500</item>
+        <item>15000</item>
+        <item>17500</item>
+        <item>20000</item>
+        <item>50000</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>10</item>
+        <item>20</item>
+        <item>40</item>
+        <item>70</item>
+        <item>110</item>
+        <item>160</item>
+        <item>200</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessDisplayValuesNits">
+        <item>9</item>
+        <item>14</item>
+        <item>44</item>
+        <item>67</item>
+        <item>86</item>
+        <item>104</item>
+        <item>132</item>
+        <item>148</item>
+        <item>162</item>
+        <item>174</item>
+        <item>190</item>
+        <item>206</item>
+        <item>222</item>
+        <item>287</item>
+        <item>331</item>
+        <item>366</item>
+        <item>382</item>
+        <item>389</item>
+        <item>393</item>
+        <item>400</item>
+        <item>500</item>
+        <item>599</item>
+        <item>701</item>
+        <item>801</item>
+        <item>1999</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessNits">
+        <item>5</item>
+        <item>9</item>
+        <item>14</item>
+        <item>44</item>
+        <item>67</item>
+        <item>86</item>
+        <item>104</item>
+        <item>132</item>
+        <item>148</item>
+        <item>162</item>
+        <item>174</item>
+        <item>190</item>
+        <item>206</item>
+        <item>222</item>
+        <item>287</item>
+        <item>331</item>
+        <item>366</item>
+        <item>382</item>
+        <item>389</item>
+        <item>393</item>
+        <item>400</item>
+        <item>500</item>
+        <item>590</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessBacklight">
+        <item>2</item>
+        <item>4</item>
+        <item>6</item>
+        <item>19</item>
+        <item>29</item>
+        <item>37</item>
+        <item>45</item>
+        <item>57</item>
+        <item>64</item>
+        <item>70</item>
+        <item>75</item>
+        <item>82</item>
+        <item>89</item>
+        <item>96</item>
+        <item>124</item>
+        <item>143</item>
+        <item>158</item>
+        <item>165</item>
+        <item>168</item>
+        <item>170</item>
+        <item>173</item>
+        <item>216</item>
+        <item>255</item>
+    </integer-array>
+
+    <string name="config_mainBuiltInDisplayCutout">M-221.5,2.2c5,2.5 9.2,6.4 11.2,10.3 0.9,1.6 5.8,13.7 10.9,26.8 9.7,24.6 12.4,29.8 19.3,36 5.3,4.8 10.6,7.4 19.8,9.8 7.4,1.8 12.5,1.9 158.2,1.9 98,0 152.9,-0.4 157.1,-1 9.9,-1.6 15.4,-3.7 22,-8.6 8.7,-6.4 12.3,-12.7 23,-40.3 10.2,-26.4 12.6,-30.3 20.9,-34.6l4.6,-2.4 -225.5,0 -225.5,0 4,2.1z</string>
+</resources>

--- a/Asus/Zenfone5-10/res/xml/power_profile.xml
+++ b/Asus/Zenfone5-10/res/xml/power_profile.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="battery.capacity">3300</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <item name="cpu.suspend">4.3</item>
+    <item name="cpu.idle">3.7</item>
+    <array name="cpu.core_speeds.cluster0">
+        <value>633600</value>
+        <value>902400</value>
+        <value>1113600</value>
+        <value>1401600</value>
+        <value>1536000</value>
+        <value>1593600</value>
+        <value>1612800</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>1113600</value>
+        <value>1401600</value>
+        <value>1747200</value>
+        <value>1766400</value>
+        <value>1785600</value>
+        <value>1804800</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>24</value>
+        <value>32</value>
+        <value>36</value>
+        <value>43</value>
+        <value>56</value>
+        <value>58</value>
+        <value>67</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>44</value>
+        <value>70</value>
+        <value>88</value>
+        <value>116</value>
+        <value>146</value>
+        <value>155</value>
+    </array>
+    <item name="screen.on">155</item>
+    <item name="screen.full">365</item>
+    <item name="camera.flashlight">212</item>
+    <item name="camera.avg">620</item>
+    <item name="video">61</item>
+    <item name="audio">30</item>
+    <item name="wifi.controller.idle">0.48</item>
+    <item name="wifi.controller.tx">123</item>
+    <item name="bluetooth.controller.idle">0.39</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -7,6 +7,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-SystemUI-FalseLocks \
 	treble-overlay-Telephony-LTE \
 	treble-overlay-asus-zenfone5 \
+	treble-overlay-asus-zenfone5-10 \
 	treble-overlay-asus-zenfone5z \
 	treble-overlay-asus-zenfonelivel1za550kl \
 	treble-overlay-asus-zenfonemaxm2 \
@@ -83,8 +84,8 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-a40 \
 	treble-overlay-samsung-a50 \
 	treble-overlay-samsung-a51x \
-	treble-overlay-samsung-a80 \
 	treble-overlay-samsung-a60q \
+	treble-overlay-samsung-a80 \
 	treble-overlay-samsung-gta3xl \
 	treble-overlay-samsung-s10e \
 	treble-overlay-samsung-s9-systemui \


### PR DESCRIPTION
Q vendor identifies differently, hence the need for a separate overlay.
Also fixed a sorting issue in the makefile.