### PR TITLE
Fixes for Redmi 7A overlay

### DIFF
--- a/Xiaomi/Redmi7A/res/values/config.xml
+++ b/Xiaomi/Redmi7A/res/values/config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <integer-array name="config_autoBrightnessLcdBacklightValues">
-      <item>3</item>
-      <item>3</item>
+      <item>1</item>
+      <item>1</item>
       <item>3</item>
       <item>3</item>
       <item>8</item>

--- a/Xiaomi/Redmi7A/res/values/config.xml
+++ b/Xiaomi/Redmi7A/res/values/config.xml
@@ -79,7 +79,7 @@
     <integer name="config_screenBrightnessDoze">17</integer>
     <integer name="config_screenBrightnessSettingDefault">536</integer>
     <integer name="config_screenBrightnessSettingMaximum">2048</integer>
-    <integer name="config_screenBrightnessSettingMinimum">7</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer>
     <integer name="config_bluetooth_idle_cur_ma">0</integer>
     <integer name="config_bluetooth_operating_voltage_mv">3300</integer>
     <integer name="config_bluetooth_rx_cur_ma">0</integer>

--- a/Xiaomi/Redmi7A/res/values/config.xml
+++ b/Xiaomi/Redmi7A/res/values/config.xml
@@ -71,7 +71,7 @@
     <bool name="config_displayBlanksAfterDoze">true</bool>
     <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
     <fraction name="config_autoBrightnessAdjustmentMaxGamma">100.0%</fraction>
-    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <fraction name="config_maximumScreenDimRatio">30%</fraction>
     <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
     <integer name="config_autoBrightnessDarkeningLightDebounce">2000</integer>
     <integer name="config_screenBrightnessDark">1</integer>

--- a/Xiaomi/Redmi7A/res/values/config.xml
+++ b/Xiaomi/Redmi7A/res/values/config.xml
@@ -85,7 +85,7 @@
     <integer name="config_bluetooth_rx_cur_ma">0</integer>
     <integer name="config_bluetooth_tx_cur_ma">0</integer>
     <integer name="config_shutdownBatteryTemperature">600</integer>
-    <dimen name="rounded_corner_radius">0px</dimen>
-    <dimen name="rounded_corner_radius_top">20px</dimen>
-    <dimen name="rounded_corner_radius_bottom">20px</dimen>
+    <dimen name="rounded_corner_radius">12px</dimen>
+    <dimen name="rounded_corner_radius_top">12px</dimen>
+    <dimen name="rounded_corner_radius_bottom">12px</dimen>
 </resources>


### PR DESCRIPTION
Round corners weren't working and minimum brightness level was annoyingly high