### PR TITLE
Add overlay for Redmi 10X 5G (atom)

### DIFF
--- a/Xiaomi/Redmi10X5G/Android.mk
+++ b/Xiaomi/Redmi10X5G/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-redmi10x5g
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/Redmi10X5G/AndroidManifest.xml
+++ b/Xiaomi/Redmi10X5G/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.redmi10x5g"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*edmi/atom*"
+		android:priority="116"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/Redmi10X5G/AndroidManifest.xml
+++ b/Xiaomi/Redmi10X5G/AndroidManifest.xml
@@ -5,6 +5,6 @@
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
                 android:requiredSystemPropertyValue="+*edmi/atom*"
-		android:priority="116"
+		android:priority="823"
 		android:isStatic="true" />
 </manifest>

--- a/Xiaomi/Redmi10X5G/res/values/config.xml
+++ b/Xiaomi/Redmi10X5G/res/values/config.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Custom Config  -->
-    <bool name="config_enableHapticTextHandle">true</bool>
-    <bool name="config_notifyClientOnFingerprintCancelSuccess">true</bool>
-    <bool name="config_sendCameraStatusIntent">true</bool>
-    <bool name="config_supportsInDisplayFingerprint">true</bool>
-    <bool name="config_supportsScreenOffInDisplayFingerprint">true</bool>
-    <bool name="config_haveHigherAspectRatioScreen">true</bool>
-    <integer name="config_navBarInteractionMode">2</integer>
     <!--
 	
 		Config From MIUI V12.5.2.0 China Version
@@ -192,9 +184,6 @@
         <item>4000</item>
         <item>4500</item>
     </integer-array>
-    <string-array name="config_biometric_sensors">
-        <item>0:2:15</item>
-    </string-array>
     <string-array name="networkAttributes">
         <item>wifi,1,1,1,-1,true</item>
         <item>mobile,0,0,0,-1,true</item>
@@ -280,23 +269,23 @@
     <bool name="config_showNavigationBar">true</bool>
     <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
     <bool name="config_sustainedPerformanceModeSupported">false</bool>
-    <bool name="config_enableMultiUserUI">true</bool>
+    
     <bool name="config_enableBurnInProtection">false</bool>
     <bool name="config_suspendWhenScreenOffDueToProximity">false</bool>
-    <bool name="config_unplugTurnsOnScreen">true</bool>
-    <bool name="config_cellBroadcastAppLinks">false</bool>
-    <bool name="config_dozeAlwaysOnEnabled">true</bool>
+
+
+
     <bool name="config_pinnerCameraApp">false</bool>
     <bool name="config_enableNetworkLocationOverlay">false</bool>
     <bool name="config_pinnerHomeApp">false</bool>
-    <bool name="config_enableWifiDisplay">false</bool>
-    <bool name="config_camera_sound_forced">true</bool>
+
+
     <bool name="config_carrier_wfc_ims_available">false</bool>
     <bool name="config_speed_up_audio_on_mt_calls">false</bool>
-    <bool name="config_carrier_volte_tty_supported">true</bool>
+
     <bool name="config_supportDoubleTapWake">false</bool>
     <bool name="config_dynamic_bind_ims">true</bool>
-    <bool name="config_eap_sim_based_auth_supported">true</bool>
+
     <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
     <dimen name="status_bar_height_portrait">24dp</dimen>
     <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
@@ -305,23 +294,20 @@
     <integer name="config_autoBrightnessDarkeningLightDebounce">8000</integer>
     <integer name="config_brightness_ramp_rate_fast">180</integer>
     <integer name="config_brightness_ramp_rate_slow">60</integer>
-    <integer name="config_defaultRingVibrationIntensity">2</integer>
+
     <integer name="config_screenBrightnessDark">1</integer>
     <integer name="config_screenBrightnessDim">10</integer>
-    <integer name="config_safe_media_volume_index">10</integer>
-    <integer name="config_wifi_framework_wifi_score_bad_rssi_threshold_24GHz">-83</integer>
-    <integer name="config_wifi_framework_wifi_score_bad_rssi_threshold_5GHz">-80</integer>
-    <integer name="config_wifi_framework_wifi_score_low_rssi_threshold_24GHz">-73</integer>
-    <integer name="config_wifi_framework_wifi_score_low_rssi_threshold_5GHz">-70</integer>
+
+
     <integer name="config_screenBrightnessDoze">1</integer>
-    <integer name="config_multiuserMaximumUsers">4</integer>
-    <integer name="config_num_physical_slots">1</integer>
-    <integer name="config_defaultHapticFeedbackIntensity">2</integer>
+
+
+
     <integer name="config_screenBrightnessForVrSettingDefault">86</integer>
-    <integer name="config_defaultNotificationVibrationIntensity">2</integer>
+
     <integer name="config_screenBrightnessForVrSettingMinimum">79</integer>
     <integer name="config_screenBrightnessForVrSettingMaximum">255</integer>
-    <integer name="config_wakeUpDelayDoze">0</integer>
+
     <integer name="config_screenBrightnessSettingDefault">102</integer>
     <integer name="config_screenBrightnessSettingMaximum">255</integer>
     <integer name="config_screenBrightnessSettingMinimum">10</integer>
@@ -331,9 +317,8 @@
     <integer name="config_lightSensorWarmupTime">0</integer>
     <integer name="config_bluetooth_tx_cur_ma">0</integer>
     <integer name="config_shutdownBatteryTemperature">599</integer>
-    <integer name="config_bluetooth_max_advertisers">0</integer>
-    <integer name="config_bluetooth_max_scan_filters">0</integer>
-    <string name="config_qualified_networks_service_package">com.android.phone</string>
+
+
+
     <string name="config_ims_package">com.mediatek.ims</string>
-    <string name="config_wifi_tcp_buffers">524288,1048576,4194304,262144,524288,3670016</string>
 </resources>

--- a/Xiaomi/Redmi10X5G/res/values/config.xml
+++ b/Xiaomi/Redmi10X5G/res/values/config.xml
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Custom Config  -->
+    <bool name="config_enableHapticTextHandle">true</bool>
+    <bool name="config_notifyClientOnFingerprintCancelSuccess">true</bool>
+    <bool name="config_sendCameraStatusIntent">true</bool>
+    <bool name="config_supportsInDisplayFingerprint">true</bool>
+    <bool name="config_supportsScreenOffInDisplayFingerprint">true</bool>
+    <bool name="config_haveHigherAspectRatioScreen">true</bool>
+    <integer name="config_navBarInteractionMode">2</integer>
+    <!--
+	
+		Config From MIUI V12.5.2.0 China Version
+	
+	-->
+    <integer-array name="config_autoBrightnessDisplayValuesNits">
+        <item>4</item>
+        <item>5</item>
+        <item>9</item>
+        <item>16</item>
+        <item>24</item>
+        <item>31</item>
+        <item>35</item>
+        <item>48</item>
+        <item>61</item>
+        <item>83</item>
+        <item>87</item>
+        <item>87</item>
+        <item>88</item>
+        <item>88</item>
+        <item>88</item>
+        <item>89</item>
+        <item>89</item>
+        <item>89</item>
+        <item>90</item>
+        <item>90</item>
+        <item>91</item>
+        <item>91</item>
+        <item>91</item>
+        <item>92</item>
+        <item>92</item>
+        <item>93</item>
+        <item>95</item>
+        <item>96</item>
+        <item>98</item>
+        <item>98</item>
+        <item>100</item>
+        <item>101</item>
+        <item>102</item>
+        <item>104</item>
+        <item>105</item>
+        <item>107</item>
+        <item>108</item>
+        <item>110</item>
+        <item>111</item>
+        <item>113</item>
+        <item>114</item>
+        <item>116</item>
+        <item>117</item>
+        <item>119</item>
+        <item>120</item>
+        <item>142</item>
+        <item>164</item>
+        <item>190</item>
+        <item>216</item>
+        <item>243</item>
+        <item>272</item>
+        <item>302</item>
+        <item>313</item>
+        <item>386</item>
+        <item>430</item>
+        <item>434</item>
+        <item>445</item>
+        <item>445</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>10</item>
+        <item>10</item>
+        <item>12</item>
+        <item>15</item>
+        <item>18</item>
+        <item>21</item>
+        <item>24</item>
+        <item>30</item>
+        <item>37</item>
+        <item>43</item>
+        <item>47</item>
+        <item>50</item>
+        <item>50</item>
+        <item>50</item>
+        <item>51</item>
+        <item>51</item>
+        <item>51</item>
+        <item>51</item>
+        <item>52</item>
+        <item>52</item>
+        <item>52</item>
+        <item>52</item>
+        <item>52</item>
+        <item>53</item>
+        <item>53</item>
+        <item>54</item>
+        <item>55</item>
+        <item>56</item>
+        <item>57</item>
+        <item>57</item>
+        <item>58</item>
+        <item>59</item>
+        <item>59</item>
+        <item>60</item>
+        <item>61</item>
+        <item>62</item>
+        <item>63</item>
+        <item>64</item>
+        <item>65</item>
+        <item>66</item>
+        <item>67</item>
+        <item>68</item>
+        <item>68</item>
+        <item>69</item>
+        <item>70</item>
+        <item>84</item>
+        <item>97</item>
+        <item>113</item>
+        <item>128</item>
+        <item>144</item>
+        <item>160</item>
+        <item>177</item>
+        <item>200</item>
+        <item>220</item>
+        <item>237</item>
+        <item>250</item>
+        <item>255</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>4</item>
+        <item>6</item>
+        <item>8</item>
+        <item>10</item>
+        <item>15</item>
+        <item>20</item>
+        <item>25</item>
+        <item>30</item>
+        <item>35</item>
+        <item>40</item>
+        <item>45</item>
+        <item>50</item>
+        <item>55</item>
+        <item>60</item>
+        <item>65</item>
+        <item>70</item>
+        <item>75</item>
+        <item>80</item>
+        <item>85</item>
+        <item>90</item>
+        <item>95</item>
+        <item>100</item>
+        <item>120</item>
+        <item>140</item>
+        <item>160</item>
+        <item>180</item>
+        <item>200</item>
+        <item>220</item>
+        <item>240</item>
+        <item>260</item>
+        <item>280</item>
+        <item>300</item>
+        <item>320</item>
+        <item>340</item>
+        <item>360</item>
+        <item>380</item>
+        <item>400</item>
+        <item>420</item>
+        <item>440</item>
+        <item>460</item>
+        <item>480</item>
+        <item>500</item>
+        <item>700</item>
+        <item>900</item>
+        <item>1100</item>
+        <item>1300</item>
+        <item>1500</item>
+        <item>1700</item>
+        <item>1900</item>
+        <item>2200</item>
+        <item>2500</item>
+        <item>3000</item>
+        <item>3500</item>
+        <item>4000</item>
+        <item>4500</item>
+    </integer-array>
+    <string-array name="config_biometric_sensors">
+        <item>0:2:15</item>
+    </string-array>
+    <string-array name="networkAttributes">
+        <item>wifi,1,1,1,-1,true</item>
+        <item>mobile,0,0,0,-1,true</item>
+        <item>mobile_mms,2,0,2,300000,true</item>
+        <item>mobile_supl,3,0,2,60000,true</item>
+        <item>mobile_dun,4,0,2,60000,true</item>
+        <item>mobile_hipri,5,0,3,60000,true</item>
+        <item>mobile_fota,10,0,2,60000,true</item>
+        <item>mobile_ims,11,0,-1,-1,true</item>
+        <item>mobile_cbs,12,0,2,60000,true</item>
+        <item>bluetooth,7,7,2,-1,true</item>
+        <item>ethernet,9,9,4,-1,true</item>
+        <item>wifi_p2p,13,1,0,-1,true</item>
+        <item>mobile_ia,14,0,2,-1,true</item>
+        <item>mobile_emergency,15,0,2,-1,true</item>
+        <item>mobile_dm,20,0,3,60000,true</item>
+        <item>mobile_wap,21,0,3,60000,true</item>
+        <item>mobile_net,22,0,3,60000,true</item>
+        <item>mobile_cmmail,23,0,3,60000,true</item>
+        <item>mobile_rcse,24,0,3,60000,true</item>
+        <item>mobile_xcap,25,0,3,60000,true</item>
+        <item>mobile_rcs,26,0,3,60000,true</item>
+        <item>mobile_bip,27,0,3,60000,true</item>
+        <item>mobile_vsim,28,0,-1,60000,true</item>
+        <item>mobile_preempt,29,0,9,60000,true</item>
+        <item>wifi_slave,30,1,1,-1,true</item>
+    </string-array>
+    <string-array name="radioAttributes">
+        <item>1,1</item>
+        <item>0,1</item>
+        <item>7,1</item>
+        <item>9,1</item>
+    </string-array>
+    <string-array name="config_tether_bluetooth_regexs">
+        <item>bt-pan</item>
+        <item>bt-dun</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>ap\\d</item>
+    </string-array>
+    <integer-array name="config_keyboardTapVibePattern">
+        <item>40</item>
+    </integer-array>
+    <integer-array name="config_longPressVibePattern">
+        <item>0</item>
+        <item>1</item>
+        <item>20</item>
+        <item>21</item>
+    </integer-array>
+    <integer-array name="config_virtualKeyVibePattern">
+        <item>0</item>
+        <item>10</item>
+        <item>20</item>
+        <item>30</item>
+    </integer-array>
+    <array name="config_minimumBrightnessCurveNits">
+        <item>0.0</item>
+        <item>50.0</item>
+        <item>90.0</item>
+    </array>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_setColorTransformAccelerated">true</bool>
+    <bool name="config_supportAudioSourceUnprocessed">false</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_bluetooth_le_peripheral_mode_supported">false</bool>
+    <bool name="config_carrier_volte_available">false</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">false</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_intrusiveNotificationLed">true</bool>
+    <bool name="config_lidControlsSleep">true</bool>
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">false</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_batched_scan_supported">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+    <bool name="config_displayBlanksAfterDoze">false</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">false</bool>
+    <bool name="config_dozeAfterScreenOffByDefault">true</bool>
+    <bool name="config_dozePulsePickup">false</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="config_sustainedPerformanceModeSupported">false</bool>
+    <bool name="config_enableMultiUserUI">true</bool>
+    <bool name="config_enableBurnInProtection">false</bool>
+    <bool name="config_suspendWhenScreenOffDueToProximity">false</bool>
+    <bool name="config_unplugTurnsOnScreen">true</bool>
+    <bool name="config_cellBroadcastAppLinks">false</bool>
+    <bool name="config_dozeAlwaysOnEnabled">true</bool>
+    <bool name="config_pinnerCameraApp">false</bool>
+    <bool name="config_enableNetworkLocationOverlay">false</bool>
+    <bool name="config_pinnerHomeApp">false</bool>
+    <bool name="config_enableWifiDisplay">false</bool>
+    <bool name="config_camera_sound_forced">true</bool>
+    <bool name="config_carrier_wfc_ims_available">false</bool>
+    <bool name="config_speed_up_audio_on_mt_calls">false</bool>
+    <bool name="config_carrier_volte_tty_supported">true</bool>
+    <bool name="config_supportDoubleTapWake">false</bool>
+    <bool name="config_dynamic_bind_ims">true</bool>
+    <bool name="config_eap_sim_based_auth_supported">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
+    <dimen name="status_bar_height_portrait">24dp</dimen>
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">4000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">8000</integer>
+    <integer name="config_brightness_ramp_rate_fast">180</integer>
+    <integer name="config_brightness_ramp_rate_slow">60</integer>
+    <integer name="config_defaultRingVibrationIntensity">2</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">10</integer>
+    <integer name="config_safe_media_volume_index">10</integer>
+    <integer name="config_wifi_framework_wifi_score_bad_rssi_threshold_24GHz">-83</integer>
+    <integer name="config_wifi_framework_wifi_score_bad_rssi_threshold_5GHz">-80</integer>
+    <integer name="config_wifi_framework_wifi_score_low_rssi_threshold_24GHz">-73</integer>
+    <integer name="config_wifi_framework_wifi_score_low_rssi_threshold_5GHz">-70</integer>
+    <integer name="config_screenBrightnessDoze">1</integer>
+    <integer name="config_multiuserMaximumUsers">4</integer>
+    <integer name="config_num_physical_slots">1</integer>
+    <integer name="config_defaultHapticFeedbackIntensity">2</integer>
+    <integer name="config_screenBrightnessForVrSettingDefault">86</integer>
+    <integer name="config_defaultNotificationVibrationIntensity">2</integer>
+    <integer name="config_screenBrightnessForVrSettingMinimum">79</integer>
+    <integer name="config_screenBrightnessForVrSettingMaximum">255</integer>
+    <integer name="config_wakeUpDelayDoze">0</integer>
+    <integer name="config_screenBrightnessSettingDefault">102</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">10</integer>
+    <integer name="config_bluetooth_idle_cur_ma">0</integer>
+    <integer name="config_bluetooth_operating_voltage_mv">0</integer>
+    <integer name="config_bluetooth_rx_cur_ma">0</integer>
+    <integer name="config_lightSensorWarmupTime">0</integer>
+    <integer name="config_bluetooth_tx_cur_ma">0</integer>
+    <integer name="config_shutdownBatteryTemperature">599</integer>
+    <integer name="config_bluetooth_max_advertisers">0</integer>
+    <integer name="config_bluetooth_max_scan_filters">0</integer>
+    <string name="config_qualified_networks_service_package">com.android.phone</string>
+    <string name="config_ims_package">com.mediatek.ims</string>
+    <string name="config_wifi_tcp_buffers">524288,1048576,4194304,262144,524288,3670016</string>
+</resources>

--- a/Xiaomi/Redmi10X5G/res/xml/power_profile.xml
+++ b/Xiaomi/Redmi10X5G/res/xml/power_profile.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">79.92</item>
+    <item name="screen.full">307.98</item>
+    <item name="bluetooth.active">60.71</item>
+    <item name="bluetooth.on">1.25</item>
+    <item name="wifi.on">0.22</item>
+    <item name="wifi.active">309.53</item>
+    <item name="wifi.scan">19.03</item>
+    <item name="dsp.audio">31.43</item>
+    <item name="dsp.video">51.69</item>
+    <item name="camera.flashlight">88.97</item>
+    <item name="camera.avg">464.23</item>
+    <item name="gps.on">27.71</item>
+    <item name="radio.active">262.53</item>
+    <item name="radio.scanning">78.78</item>
+    <array name="radio.on">
+        <value>5.08</value>
+        <value>5.08</value>
+    </array>
+    <item name="modem.controller.idle">0</item>
+    <item name="modem.controller.rx">0</item>
+    <item name="modem.controller.tx">0</item>
+    <item name="modem.controller.voltage">0</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>500000</value>
+        <value>650000</value>
+        <value>756000</value>
+        <value>862000</value>
+        <value>968000</value>
+        <value>1075000</value>
+        <value>1181000</value>
+        <value>1358000</value>
+        <value>1500000</value>
+        <value>1541000</value>
+        <value>1625000</value>
+        <value>1687000</value>
+        <value>1750000</value>
+        <value>1812000</value>
+        <value>1875000</value>
+        <value>2000000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>45.78</value>
+        <value>48.93</value>
+        <value>50.7</value>
+        <value>52.42</value>
+        <value>54.26</value>
+        <value>56.02</value>
+        <value>58.16</value>
+        <value>61.55</value>
+        <value>64.13</value>
+        <value>65.38</value>
+        <value>66.16</value>
+        <value>67.40</value>
+        <value>73.58</value>
+        <value>74.61</value>
+        <value>78.11</value>
+        <value>83.35</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>774000</value>
+        <value>841000</value>
+        <value>925000</value>
+        <value>1050000</value>
+        <value>1133000</value>
+        <value>1175000</value>
+        <value>1300000</value>
+        <value>1383000</value>
+        <value>1548000</value>
+        <value>1633000</value>
+        <value>1800000</value>
+        <value>1933000</value>
+        <value>2133000</value>
+        <value>2266000</value>
+        <value>2433000</value>
+        <value>2600000</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>74.43</value>
+        <value>77.11</value>
+        <value>80.60</value>
+        <value>84.13</value>
+        <value>90</value>
+        <value>98.88</value>
+        <value>121.08</value>
+        <value>135.93</value>
+        <value>139.49</value>
+        <value>151.76</value>
+        <value>165.09</value>
+        <value>176.64</value>
+        <value>185.34</value>
+        <value>193.8</value>
+        <value>197.62</value>
+        <value>207.58</value>
+    </array>
+    <item name="cpu.awake">31.13</item>
+    <item name="cpu.idle">5.95</item>
+    <item name="battery.capacity">4520</item>
+    <item name="wifi.controller.idle">0</item>
+    <item name="wifi.controller.rx">0</item>
+    <item name="wifi.controller.tx">0</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">0</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -153,6 +153,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-mipad4 \
 	treble-overlay-xiaomi-miplay \
 	treble-overlay-xiaomi-pocof1 \
+	treble-overlay-xiaomi-redmi10x5g \
 	treble-overlay-xiaomi-redmi6 \
 	treble-overlay-xiaomi-redmi6a \
 	treble-overlay-xiaomi-redmi6pro \
@@ -169,5 +170,4 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redminote7 \
 	treble-overlay-xiaomi-redminote8pro \
 	treble-overlay-xiaomi-redmis2 \
-	treble-overlay-xiaomi-redmi10x5g \
 

--- a/overlay.mk
+++ b/overlay.mk
@@ -169,4 +169,5 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redminote7 \
 	treble-overlay-xiaomi-redminote8pro \
 	treble-overlay-xiaomi-redmis2 \
+	treble-overlay-xiaomi-redmi10x5g \
 


### PR DESCRIPTION
This overlay aims to fix brightness, fingerprint-in-screen and power statistics problems in Redmi 10X 5G running GSI. I have tested on my phone running PixelExperience Plus 11.