### PR TITLE
InfinixNote8: Define SoftAP ACS hardware ability

### DIFF
--- a/Infinix/Note8/res/values/config.xml
+++ b/Infinix/Note8/res/values/config.xml
@@ -63,6 +63,7 @@
     <bool name="config_wifi_dual_band_support">true</bool>
     <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
     <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
+    <bool name="config_wifi_softap_acs_supported">true</bool>
     <bool name="skip_restoring_network_selection">true</bool>
     <bool name="config_enableNetworkLocationOverlay">true</bool>
     <bool name="config_enableFusedLocationOverlay">true</bool>

--- a/tests/knownKeys
+++ b/tests/knownKeys
@@ -134,3 +134,4 @@ config_ambientDarkeningThresholds
 config_ambientThresholdLevels
 config_screenBrighteningThresholds
 config_screenDarkeningThresholds
+config_wifi_softap_acs_supported


### PR DESCRIPTION
Reference: https://source.android.com/devices/tech/connect/wifi-softap-tethering

_P.S. : Since the key isn't defined in "knownKeys" file, I've added it for your pleasure_