### PR TITLE
Configure AOD for Meizu 18

### DIFF
--- a/Meizu/M2181-SystemUI/res/values-v31/config.xml
+++ b/Meizu/M2181-SystemUI/res/values-v31/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="physical_power_button_center_screen_location_y">960px</dimen>
+</resources>

--- a/Meizu/M2181/res/values/config.xml
+++ b/Meizu/M2181/res/values/config.xml
@@ -2,11 +2,16 @@
 <resources>
     <bool name="config_useDevInputEventForAudioJack">true</bool>
     <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    <bool name="config_enableBurnInProtection">true</bool>
 
     <dimen name="status_bar_height_portrait">96px</dimen>
     <dimen name="status_bar_height_landscape">28dp</dimen>
     <dimen name="quick_qs_offset_height">@dimen/status_bar_height_portrait</dimen>
 
+    <integer name="config_screenBrightnessDoze">5</integer>
     <integer name="config_screenBrightnessSettingMinimum">1</integer>
 
     <string name="config_mainBuiltInDisplayCutout">M -48,0 L -48,96 L 48,96 L 48,0 Z</string>


### PR DESCRIPTION
- Note to others: setting `config_displayBlanksAfterDoze` breaks the transition in S
- `physical_power_button_center_screen_location_y` is added on S, so I put it in `values-v31`, shouldn't break R this way