### PR TITLE
Add Volte for Huawei device hi6250

### DIFF
--- a/HW-IMS/res/values/config.xml
+++ b/HW-IMS/res/values/config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="config_ims_package">com.huawei.ims</string>
+	<bool name="config_dynamic_bind_ims">true</bool>
 	<bool name="config_carrier_volte_available">true</bool>
-<!--	<bool name="config_dynamic_bind_ims">true</bool>-->
+	<bool name="config_device_volte_available">true</bool>
+	<bool name="config_device_wfc_ims_available">true</bool>
 </resources>

--- a/Telephony/HW-IMS/Android.mk
+++ b/Telephony/HW-IMS/Android.mk
@@ -1,0 +1,6 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-telephony-hw-ims
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Telephony/HW-IMS/AndroidManifest.xml
+++ b/Telephony/HW-IMS/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.hwims_telephony"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.phone"
+		android:priority="79"
+		/>
+</manifest>

--- a/Telephony/HW-IMS/res/values/config.xml
+++ b/Telephony/HW-IMS/res/values/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="config_ims_mmtel_package">com.huawei.ims</string>
+
+</resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -150,10 +150,10 @@ PRODUCT_PACKAGES += \
 	treble-overlay-teclast-t30 \
 	treble-overlay-tecno-camon11 \
 	treble-overlay-telephony-caf-ims \
+	treble-overlay-telephony-hw-ims \
 	treble-overlay-telephony-mtk-ims \
 	treble-overlay-telephony-slsi-ims \
 	treble-overlay-telephony-sprd-ims \
-	treble-overlay-telephony-hw-ims \
 	treble-overlay-teracube-2e \
 	treble-overlay-teracube-v7101o \
 	treble-overlay-tethering \

--- a/overlay.mk
+++ b/overlay.mk
@@ -153,6 +153,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-telephony-mtk-ims \
 	treble-overlay-telephony-slsi-ims \
 	treble-overlay-telephony-sprd-ims \
+	treble-overlay-telephony-hw-ims \
 	treble-overlay-teracube-2e \
 	treble-overlay-teracube-v7101o \
 	treble-overlay-tethering \


### PR DESCRIPTION
Here is a patch which allows to support in Android 11 the volte via the HuaweiIMS ims. You also need to modify Treble App