### PR TITLE
Update A51 overlays

### DIFF
--- a/Samsung/A51-SystemUI/Android.mk
+++ b/Samsung/A51-SystemUI/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-samsung-a51-systemui
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Samsung/A51-SystemUI/AndroidManifest.xml
+++ b/Samsung/A51-SystemUI/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.samsung.a51.systemui"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.systemui"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*samsung/a51*"
+		android:priority="102"
+		android:isStatic="true" />
+</manifest>

--- a/Samsung/A51-SystemUI/res/values/config.xml
+++ b/Samsung/A51-SystemUI/res/values/config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_padding_start">40px</dimen>
+    <dimen name="status_bar_padding_end">40px</dimen>
+    <dimen name="status_bar_padding_top">35px</dimen>
+</resources>

--- a/Samsung/A51/res/values/config.xml
+++ b/Samsung/A51/res/values/config.xml
@@ -1,30 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	    <string-array name="config_tether_usb_regexs">
+    <string-array name="config_tether_usb_regexs">
         <item>rndis0</item>
     </string-array>
-	    <integer-array name="config_keyboardTapVibePattern">
+
+    <integer-array name="config_keyboardTapVibePattern">
         <item>40</item>
     </integer-array>
-	    <integer-array name="config_longPressVibePattern">
+    <integer-array name="config_longPressVibePattern">
         <item>0</item>
         <item>1</item>
         <item>20</item>
         <item>21</item>
     </integer-array>
-	    <integer-array name="config_virtualKeyVibePattern">
+    <integer-array name="config_virtualKeyVibePattern">
         <item>0</item>
         <item>10</item>
         <item>20</item>
         <item>30</item>
     </integer-array>
-	    <integer name="config_autoBrightnessBrighteningLightDebounce">4000</integer>
-        <integer name="config_screenBrightnessSettingDefault">102</integer>
-        <integer name="config_screenBrightnessSettingMaximum">255</integer>
-        <integer name="config_screenBrightnessSettingMinimum">10</integer>
-	    <integer name="config_screenBrightnessDoze">1</integer>
-		<integer name="config_screenBrightnessDark">1</integer>
-	    <array name="config_autoBrightnessDisplayValuesNits">
+
+    <integer name="config_autoBrightnessBrighteningLightDebounce">4000</integer>
+    <integer name="config_screenBrightnessSettingDefault">102</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">10</integer>
+    <integer name="config_screenBrightnessDoze">1</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+
+    <array name="config_autoBrightnessDisplayValuesNits">
         <item>10</item>
         <item>12</item>
         <item>15</item>
@@ -61,8 +64,9 @@
         <item>675</item>
         <item>675</item>
         <item>700</item>
-    </array>
-	   <integer-array name="config_autoBrightnessLcdBacklightValues">
+   </array>
+
+   <integer-array name="config_autoBrightnessLcdBacklightValues">
         <item>6</item>
         <item>6</item>
         <item>6</item>
@@ -91,7 +95,7 @@
         <item>19999</item>
         <item>20000</item>
     </integer-array>
-	    <integer-array name="config_screenBrightnessBacklight">
+    <integer-array name="config_screenBrightnessBacklight">
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -629,5 +633,8 @@
         <item>675</item>
         <item>700</item>
     </array>
-	    <bool name="config_automatic_brightness_available">true</bool>
+
+     <bool name="config_automatic_brightness_available">true</bool>
+     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+     <bool name="config_supportDoubleTapWake">true</bool>
 </resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -124,6 +124,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-a40 \
 	treble-overlay-samsung-a50 \
 	treble-overlay-samsung-a51 \
+	treble-overlay-samsung-a51-systemui \
 	treble-overlay-samsung-a51x \
 	treble-overlay-samsung-a60q \
 	treble-overlay-samsung-a7 \


### PR DESCRIPTION
* Enable AoD and dt2w options by default on a51.
* Add a systemui overlay to align status bar icons with the punch hole cutout vertically.