### PR TITLE
[Samsung Galaxy A52 overlay] Mobile data fixed

### DIFF
--- a/Samsung/A51/res/values/config.xml
+++ b/Samsung/A51/res/values/config.xml
@@ -636,5 +636,5 @@
 
      <bool name="config_automatic_brightness_available">true</bool>
      <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-     <bool name="config_dozePulsePickup">true</bool>
+     <bool name="config_supportDoubleTapWake">true</bool>
 </resources>

--- a/Samsung/A51/res/values/config.xml
+++ b/Samsung/A51/res/values/config.xml
@@ -636,5 +636,5 @@
 
      <bool name="config_automatic_brightness_available">true</bool>
      <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-     <bool name="config_supportDoubleTapWake">true</bool>
+     <bool name="config_dozePulsePickup">true</bool>
 </resources>

--- a/Samsung/A52/res/values/arrays.xml
+++ b/Samsung/A52/res/values/arrays.xml
@@ -57,19 +57,6 @@
         <item>20000</item>
         <item>40000</item>
     </integer-array>
-    <string-array name="config_mobile_tcp_buffers">
-        <item>5gnr:2097152,6291456,16777216,512000,2097152,8388608</item>
-        <item>lte:2097152,4194304,8388608,262144,524288,1048576</item>
-        <item>lte_ca:4096,6291456,12582912,4096,1048576,2097152</item>
-        <item>umts:4094,87380,1220608,4096,16384,1220608</item>
-        <item>hspa:4094,87380,1220608,4096,16384,1220608</item>
-        <item>hsupa:4094,87380,1220608,4096,16384,1220608</item>
-        <item>hsdpa:4094,87380,1220608,4096,16384,1220608</item>
-        <item>hspap:4094,87380,1220608,4096,16384,1220608</item>
-        <item>edge:4093,26280,35040,4096,16384,35040</item>
-        <item>gprs:4092,8760,11680,4096,8760,11680</item>
-        <item>evdo:4094,87380,524288,4096,16384,262144</item>
-    </string-array>
     <integer-array name="config_screenBrightnessBacklight">
         <item>0</item>
         <item>1</item>
@@ -1061,19 +1048,6 @@
     <string-array name="config_tether_usb_regexs">
         <item>usb\\d</item>
         <item>rndis\\d</item>
-    </string-array>
-    <string-array name="networkAttributes">
-        <item>wifi,1,1,1,-1,true</item>
-        <item>mobile,0,0,0,-1,true</item>
-        <item>mobile_mms,2,0,4,60000,true</item>
-        <item>mobile_supl,3,0,2,60000,true</item>
-        <item>mobile_dun,4,0,2,60000,true</item>
-        <item>mobile_hipri,5,0,3,60000,true</item>
-        <item>mobile_fota,10,0,2,60000,true</item>
-        <item>mobile_ims,11,0,2,60000,true</item>
-        <item>mobile_cbs,12,0,2,60000,true</item>
-        <item>bluetooth,7,7,2,-1,true</item>
-        <item>mobile_emergency,15,0,5,-1,true</item>
     </string-array>
     <string-array name="radioAttributes">
         <item>1,1</item>

--- a/Samsung/A52/res/values/bools.xml
+++ b/Samsung/A52/res/values/bools.xml
@@ -3,8 +3,6 @@
     <bool name="config_automatic_brightness_available">true</bool>
     <bool name="config_bluetooth_hfp_inband_ringing_support">true</bool>
     <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
-    <bool name="config_carrier_volte_available">true</bool>
-    <bool name="config_device_volte_available">true</bool>
     <bool name="config_device_vt_available">true</bool>
     <bool name="config_device_wfc_ims_available">true</bool>
     <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
@@ -18,7 +16,8 @@
     <bool name="config_wifi_background_scan_support">true</bool>
     <bool name="config_wifi_batched_scan_supported">true</bool>
     <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_enableBurnInProtection">true</bool>
     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
     <bool name="config_supportDoubleTapWake">true</bool>
-    <bool name="skip_restoring_network_selection">true</bool>
+    <bool name="config_allowAutoBrightnessWhileDozing">true</bool>
 </resources>


### PR DESCRIPTION
the (now reverted) changes to A51 were for testing something with another user, forgot to revert them before pushing and making last pull request.
With the first overlay for the A52, I copied everything from stock framework-res.apk (including some lines affecting networking stuff). I removed those lines and now it's working properly again. Also auto-brightness on AOD was added.