### PR TITLE
Redo Galaxy A20 Overlay

### DIFF
--- a/Samsung/A20/res/values/arrays.xml
+++ b/Samsung/A20/res/values/arrays.xml
@@ -1,649 +1,116 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <array name="config_autoBrightnessDisplayValuesNits">
-        <item>10</item>
-        <item>12</item>
-        <item>15</item>
-        <item>20</item>
-        <item>22.16</item>
-        <item>25.16</item>
-        <item>49.74</item>
-        <item>109.85</item>
-        <item>109.85</item>
-        <item>113</item>
-        <item>132</item>
-        <item>169.4</item>
-        <item>249.5</item>
-        <item>400</item>
-        <item>400</item>
-        <item>450</item>
-        <item>450</item>
-        <item>475</item>
-        <item>475</item>
-        <item>500</item>
-        <item>500</item>
-        <item>525</item>
-        <item>525</item>
-        <item>550</item>
-        <item>550</item>
-        <item>575</item>
-        <item>575</item>
-        <item>600</item>
-        <item>600</item>
-        <item>625</item>
-        <item>625</item>
-        <item>650</item>
-        <item>650</item>
-        <item>675</item>
-        <item>675</item>
-        <item>700</item>
-    </array>
+    <!-- Array of output values for LCD backlight corresponding to the lux values
+         in the config_autoBrightnessLevels array.  This array should have size one greater
+         than the size of the config_autoBrightnessLevels array.
+         The brightness values must be between 0 and 255 and be non-decreasing.
+         This must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLcdBacklightValues">
-        <item>6</item>
-        <item>6</item>
-        <item>6</item>
-        <item>11</item>
-        <item>79</item>
-        <item>95</item>
-        <item>141</item>
-        <item>183</item>
-        <item>200</item>
-        <item>219</item>
-        <item>255</item>
+        <item>5</item>
+        <item>22</item>
+        <item>63</item>
+        <item>70</item>
+        <item>103</item>
+        <item>128</item>
+        <item>173</item>
+        <item>214</item>
+        <item>226</item>
+        <item>233</item>
         <item>255</item>
         <item>255</item>
     </integer-array>
+
+    <!-- Array of light sensor lux values to define our levels for auto backlight brightness support.
+         The N entries of this array define N + 1 control points as follows:
+         (1-based arrays)
+
+         Point 1:            (0, value[1]):             lux <= 0
+         Point 2:     (level[1], value[2]):  0        < lux <= level[1]
+         Point 3:     (level[2], value[3]):  level[2] < lux <= level[3]
+         ...
+         Point N+1: (level[N], value[N+1]):  level[N] < lux
+
+         The control points must be strictly increasing.  Each control point
+         corresponds to an entry in the brightness backlight values arrays.
+         For example, if lux == level[1] (first element of the levels array)
+         then the brightness will be determined by value[2] (second element
+         of the brightness values array).
+
+         Spline interpolation is used to determine the auto-brightness
+         backlight values for lux levels between these control points.
+
+         Must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLevels">
-        <item>1</item>
+        <item>3</item>
         <item>5</item>
-        <item>6</item>
+        <item>7</item>
         <item>50</item>
         <item>100</item>
-        <item>500</item>
-        <item>1500</item>
-        <item>3000</item>
-        <item>4999</item>
-        <item>5000</item>
-        <item>19999</item>
+        <item>810</item>
+        <item>1675</item>
+        <item>1950</item>
+        <item>3100</item>
+        <item>4895</item>
         <item>20000</item>
     </integer-array>
-    <integer-array name="config_screenBrightnessBacklight">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-        <item>6</item>
-        <item>7</item>
-        <item>8</item>
-        <item>9</item>
-        <item>10</item>
-        <item>11</item>
-        <item>12</item>
-        <item>13</item>
-        <item>14</item>
-        <item>15</item>
-        <item>16</item>
-        <item>17</item>
-        <item>18</item>
-        <item>19</item>
-        <item>20</item>
-        <item>21</item>
-        <item>22</item>
-        <item>23</item>
-        <item>24</item>
-        <item>25</item>
-        <item>26</item>
-        <item>27</item>
-        <item>28</item>
-        <item>29</item>
-        <item>30</item>
-        <item>31</item>
-        <item>32</item>
-        <item>33</item>
-        <item>34</item>
-        <item>35</item>
-        <item>36</item>
-        <item>37</item>
-        <item>38</item>
-        <item>39</item>
-        <item>40</item>
-        <item>41</item>
-        <item>42</item>
-        <item>43</item>
-        <item>44</item>
-        <item>45</item>
-        <item>46</item>
-        <item>47</item>
-        <item>48</item>
-        <item>49</item>
-        <item>50</item>
-        <item>51</item>
-        <item>52</item>
-        <item>53</item>
-        <item>54</item>
-        <item>55</item>
-        <item>56</item>
-        <item>57</item>
-        <item>58</item>
-        <item>59</item>
-        <item>60</item>
-        <item>61</item>
-        <item>62</item>
-        <item>63</item>
-        <item>64</item>
-        <item>65</item>
-        <item>66</item>
-        <item>67</item>
-        <item>68</item>
-        <item>69</item>
-        <item>70</item>
-        <item>71</item>
-        <item>72</item>
-        <item>73</item>
-        <item>74</item>
-        <item>75</item>
-        <item>76</item>
-        <item>77</item>
-        <item>78</item>
-        <item>79</item>
-        <item>80</item>
-        <item>81</item>
-        <item>82</item>
-        <item>83</item>
-        <item>84</item>
-        <item>85</item>
-        <item>86</item>
-        <item>87</item>
-        <item>88</item>
-        <item>89</item>
-        <item>90</item>
-        <item>91</item>
-        <item>92</item>
-        <item>93</item>
-        <item>94</item>
-        <item>95</item>
-        <item>96</item>
-        <item>97</item>
-        <item>98</item>
-        <item>99</item>
-        <item>100</item>
-        <item>101</item>
-        <item>102</item>
-        <item>103</item>
-        <item>104</item>
-        <item>105</item>
-        <item>106</item>
-        <item>107</item>
-        <item>108</item>
-        <item>109</item>
-        <item>110</item>
-        <item>111</item>
-        <item>112</item>
-        <item>113</item>
-        <item>114</item>
-        <item>115</item>
-        <item>116</item>
-        <item>117</item>
-        <item>118</item>
-        <item>119</item>
-        <item>120</item>
-        <item>121</item>
-        <item>122</item>
-        <item>123</item>
-        <item>124</item>
-        <item>125</item>
-        <item>126</item>
-        <item>127</item>
-        <item>128</item>
-        <item>129</item>
-        <item>130</item>
-        <item>131</item>
-        <item>132</item>
-        <item>133</item>
-        <item>134</item>
-        <item>135</item>
-        <item>136</item>
-        <item>137</item>
-        <item>138</item>
-        <item>139</item>
-        <item>140</item>
-        <item>141</item>
-        <item>142</item>
-        <item>143</item>
-        <item>144</item>
-        <item>145</item>
-        <item>146</item>
-        <item>147</item>
-        <item>148</item>
-        <item>149</item>
-        <item>150</item>
-        <item>151</item>
-        <item>152</item>
-        <item>153</item>
-        <item>154</item>
-        <item>155</item>
-        <item>156</item>
-        <item>157</item>
-        <item>158</item>
-        <item>159</item>
-        <item>160</item>
-        <item>161</item>
-        <item>162</item>
-        <item>163</item>
-        <item>164</item>
-        <item>165</item>
-        <item>166</item>
-        <item>167</item>
-        <item>168</item>
-        <item>169</item>
-        <item>170</item>
-        <item>171</item>
-        <item>172</item>
-        <item>173</item>
-        <item>174</item>
-        <item>175</item>
-        <item>176</item>
-        <item>177</item>
-        <item>178</item>
-        <item>179</item>
-        <item>180</item>
-        <item>181</item>
-        <item>182</item>
-        <item>183</item>
-        <item>184</item>
-        <item>185</item>
-        <item>186</item>
-        <item>187</item>
-        <item>188</item>
-        <item>189</item>
-        <item>190</item>
-        <item>191</item>
-        <item>192</item>
-        <item>193</item>
-        <item>194</item>
-        <item>195</item>
-        <item>196</item>
-        <item>197</item>
-        <item>198</item>
-        <item>199</item>
-        <item>200</item>
-        <item>201</item>
-        <item>202</item>
-        <item>203</item>
-        <item>204</item>
-        <item>205</item>
-        <item>206</item>
-        <item>207</item>
-        <item>208</item>
-        <item>209</item>
-        <item>210</item>
-        <item>211</item>
-        <item>212</item>
-        <item>213</item>
-        <item>214</item>
-        <item>215</item>
-        <item>216</item>
-        <item>217</item>
-        <item>218</item>
-        <item>219</item>
-        <item>220</item>
-        <item>221</item>
-        <item>222</item>
-        <item>223</item>
-        <item>224</item>
-        <item>225</item>
-        <item>226</item>
-        <item>227</item>
-        <item>228</item>
-        <item>229</item>
-        <item>230</item>
-        <item>231</item>
-        <item>232</item>
-        <item>233</item>
-        <item>234</item>
-        <item>235</item>
-        <item>236</item>
-        <item>237</item>
-        <item>238</item>
-        <item>239</item>
-        <item>240</item>
-        <item>241</item>
-        <item>242</item>
-        <item>243</item>
-        <item>244</item>
-        <item>245</item>
-        <item>246</item>
-        <item>247</item>
-        <item>248</item>
-        <item>249</item>
-        <item>250</item>
-        <item>251</item>
-        <item>252</item>
-        <item>253</item>
-        <item>254</item>
-        <item>255</item>
-        <item>287</item>
-        <item>303</item>
-        <item>319</item>
-        <item>335</item>
-        <item>351</item>
-        <item>367</item>
-        <item>383</item>
-        <item>399</item>
-        <item>415</item>
-        <item>431</item>
-        <item>447</item>
-    </integer-array>
-    <array name="config_screenBrightnessNits">
-        <item>2</item>
-        <item>2.2</item>
-        <item>2.3</item>
-        <item>2.5</item>
-        <item>2.6</item>
-        <item>2.8</item>
-        <item>2.9</item>
-        <item>3</item>
-        <item>3.2</item>
-        <item>3.3</item>
-        <item>3.5</item>
-        <item>3.6</item>
-        <item>3.8</item>
-        <item>3.9</item>
-        <item>4</item>
-        <item>4.2</item>
-        <item>4.3</item>
-        <item>4.5</item>
-        <item>4.6</item>
-        <item>4.8</item>
-        <item>4.9</item>
-        <item>5</item>
-        <item>5.2</item>
-        <item>5.3</item>
-        <item>5.5</item>
-        <item>5.6</item>
-        <item>5.8</item>
-        <item>5.9</item>
-        <item>6</item>
-        <item>6.2</item>
-        <item>6.3</item>
-        <item>6.5</item>
-        <item>6.6</item>
-        <item>6.8</item>
-        <item>6.9</item>
-        <item>7</item>
-        <item>8</item>
-        <item>8.58</item>
-        <item>9</item>
-        <item>9.58</item>
-        <item>10</item>
-        <item>10.66</item>
-        <item>11</item>
-        <item>11.66</item>
-        <item>12</item>
-        <item>12.66</item>
-        <item>13</item>
-        <item>13.66</item>
-        <item>14</item>
-        <item>14.66</item>
-        <item>15</item>
-        <item>15.66</item>
-        <item>16</item>
-        <item>16.66</item>
-        <item>17</item>
-        <item>17.66</item>
-        <item>18</item>
-        <item>19</item>
-        <item>19.66</item>
-        <item>20</item>
-        <item>20.66</item>
-        <item>21</item>
-        <item>22.16</item>
-        <item>23</item>
-        <item>23.66</item>
-        <item>24</item>
-        <item>25.16</item>
-        <item>26</item>
-        <item>26.66</item>
-        <item>27</item>
-        <item>29</item>
-        <item>30.16</item>
-        <item>31</item>
-        <item>32.16</item>
-        <item>33</item>
-        <item>34.32</item>
-        <item>35</item>
-        <item>36.32</item>
-        <item>37</item>
-        <item>38.32</item>
-        <item>39</item>
-        <item>40.74</item>
-        <item>42</item>
-        <item>43.74</item>
-        <item>45</item>
-        <item>46.74</item>
-        <item>48</item>
-        <item>49.74</item>
-        <item>51</item>
-        <item>52.74</item>
-        <item>54</item>
-        <item>55.74</item>
-        <item>57</item>
-        <item>59.32</item>
-        <item>61</item>
-        <item>63.32</item>
-        <item>65</item>
-        <item>67.32</item>
-        <item>69</item>
-        <item>71</item>
-        <item>73</item>
-        <item>75.5</item>
-        <item>78</item>
-        <item>80.5</item>
-        <item>83</item>
-        <item>85.5</item>
-        <item>88</item>
-        <item>91</item>
-        <item>94</item>
-        <item>97.3</item>
-        <item>100</item>
-        <item>103.3</item>
-        <item>106</item>
-        <item>109.85</item>
-        <item>113</item>
-        <item>116.5</item>
-        <item>120</item>
-        <item>124.4</item>
-        <item>128</item>
-        <item>132</item>
-        <item>136</item>
-        <item>140.95</item>
-        <item>145</item>
-        <item>149.5</item>
-        <item>154</item>
-        <item>159</item>
-        <item>164</item>
-        <item>169.4</item>
-        <item>174</item>
-        <item>175.6</item>
-        <item>177.2</item>
-        <item>178.8</item>
-        <item>180.3</item>
-        <item>181.9</item>
-        <item>183.5</item>
-        <item>185</item>
-        <item>186.8</item>
-        <item>188.5</item>
-        <item>190.2</item>
-        <item>191.9</item>
-        <item>193.6</item>
-        <item>195.3</item>
-        <item>197</item>
-        <item>198.9</item>
-        <item>200.8</item>
-        <item>202.6</item>
-        <item>204.5</item>
-        <item>206.3</item>
-        <item>208.2</item>
-        <item>210</item>
-        <item>211.7</item>
-        <item>213.3</item>
-        <item>214.9</item>
-        <item>216.5</item>
-        <item>218.2</item>
-        <item>219.8</item>
-        <item>221.4</item>
-        <item>223</item>
-        <item>224.8</item>
-        <item>226.5</item>
-        <item>228.3</item>
-        <item>230</item>
-        <item>231.8</item>
-        <item>233.5</item>
-        <item>235.3</item>
-        <item>237</item>
-        <item>238.8</item>
-        <item>240.6</item>
-        <item>242.4</item>
-        <item>244.2</item>
-        <item>245.9</item>
-        <item>247.7</item>
-        <item>249.5</item>
-        <item>251.3</item>
-        <item>253</item>
-        <item>254.8</item>
-        <item>256.6</item>
-        <item>258.4</item>
-        <item>260.2</item>
-        <item>261.9</item>
-        <item>263.7</item>
-        <item>265.5</item>
-        <item>267.3</item>
-        <item>269</item>
-        <item>270.7</item>
-        <item>272.4</item>
-        <item>274.1</item>
-        <item>275.8</item>
-        <item>277.5</item>
-        <item>279.2</item>
-        <item>280.9</item>
-        <item>282.6</item>
-        <item>284.3</item>
-        <item>286</item>
-        <item>287.9</item>
-        <item>289.8</item>
-        <item>291.7</item>
-        <item>293.5</item>
-        <item>295.4</item>
-        <item>297.3</item>
-        <item>299.2</item>
-        <item>301</item>
-        <item>302.8</item>
-        <item>304.6</item>
-        <item>306.4</item>
-        <item>308.2</item>
-        <item>309.9</item>
-        <item>311.7</item>
-        <item>313.5</item>
-        <item>315.3</item>
-        <item>317</item>
-        <item>318.8</item>
-        <item>320.6</item>
-        <item>322.4</item>
-        <item>324.2</item>
-        <item>325.9</item>
-        <item>327.7</item>
-        <item>329.5</item>
-        <item>331.3</item>
-        <item>333</item>
-        <item>334.8</item>
-        <item>336.5</item>
-        <item>338.3</item>
-        <item>340</item>
-        <item>341.8</item>
-        <item>343.5</item>
-        <item>345.3</item>
-        <item>347</item>
-        <item>349.4</item>
-        <item>351.7</item>
-        <item>354</item>
-        <item>356</item>
-        <item>358</item>
-        <item>360</item>
-        <item>362</item>
-        <item>363.8</item>
-        <item>365.5</item>
-        <item>367.3</item>
-        <item>369</item>
-        <item>370.8</item>
-        <item>372.5</item>
-        <item>374.3</item>
-        <item>376</item>
-        <item>378</item>
-        <item>380</item>
-        <item>382</item>
-        <item>384</item>
-        <item>386</item>
-        <item>388</item>
-        <item>390</item>
-        <item>392</item>
-        <item>394</item>
-        <item>396</item>
-        <item>398</item>
-        <item>399</item>
-        <item>400</item>
-        <item>450</item>
-        <item>475</item>
-        <item>500</item>
-        <item>525</item>
-        <item>550</item>
-        <item>575</item>
-        <item>600</item>
-        <item>625</item>
-        <item>650</item>
-        <item>675</item>
-        <item>700</item>
-    </array>
-    <array name="config_tether_usb_regexs">
-		<item>rndis0</item>
-	</array>
+    
+    <!-- Configure mobile tcp buffer sizes in the form:
+         rat-name:rmem_min,rmem_def,rmem_max,wmem_min,wmem_def,wmem_max
+         If no value is found for the rat-name in use, the system default will be applied. -->
+    <string-array name="config_mobile_tcp_buffers">
+        <item>5gnr:2097152,6291456,16777216,512000,2097152,8388608</item>
+        <item>lte:2097152,4194304,8388608,512000,2097152,4194304</item>
+        <item>lte_ca:2097152,4194304,8388608,1048576,3145728,4194304</item>
+    </string-array>
+
+    <!-- List of regexpressions describing the interface (if any) that represent tetherable
+         USB interfaces.  If the device doesn't want to support tethering over USB this should
+         be empty.  An example would be "usb.*" -->
+    <string-array name="config_tether_usb_regexs">
+        <item>rndis0</item>
+    </string-array>
+
+    <!-- List of regexpressions describing the interface (if any) that represent tetherable
+         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
+         should be empty.  An example would be "softap.*" -->
     <string-array name="config_tether_wifi_regexs">
         <item>wlan0</item>
     </string-array>
-    <array name="networkAttributes">
-		<item>wifi,1,1,1,-1,true</item>
-		<item>mobile,0,0,0,-1,true</item>
-		<item>mobile_mms,2,0,2,240000,true</item>
-		<item>mobile_supl,3,0,2,60000,true</item>
-		<item>mobile_dun,4,0,2,60000,true</item>
-		<item>mobile_hipri,5,0,3,60000,true</item>
-		<item>bluetooth,7,7,0,-1,true</item>
-		<item>ethernet,9,9,2,-1,true</item>
-		<item>mobile_fota,10,0,2,60000,true</item>
-		<item>mobile_ims,11,0,1,-1,true</item>
-		<item>mobile_cbs,12,0,2,60000,true</item>
-		<item>wifi_p2p,13,1,0,-1,true</item>
-		<item>mobile_ia,14,0,2,-1,true</item>
-		<item>mobile_emergency,15,0,2,-1,true</item>
-		<item>mobile_bip,23,0,2,60000,true</item>
-		<item>mobile_cas,24,0,3,60000,true</item>
-		<item>mobile_xcap,27,0,2,60000,true</item>
-		<item>mobile_ent1,28,0,2,-1,true</item>
-		<item>mobile_mcx,32,0,2,-1,true</item>
-		<item>mobile_foc,30,0,2,-1,true</item>
-		<item>mobile_rcs,31,0,2,-1,true</item>
-	</array>
-    <string-array name="radioAttributes">
-        <item>1,1</item>
-        <item>0,1</item>
+
+   <!-- This string array should be overridden by the device to present a list of network
+         attributes.  This is used by the connectivity manager to decide which networks can coexist
+         based on the hardware -->
+    <!-- An Array of "[Connection name],[ConnectivityManager.TYPE_xxxx],
+         [associated radio-type],[priority],[restoral-timer(ms)],[dependencyMet]  -->
+    <!-- the 5th element "resore-time" indicates the number of milliseconds to delay
+         before automatically restore the default connection.  Set -1 if the connection
+         does not require auto-restore. -->
+    <!-- the 6th element indicates boot-time dependency-met value. -->
+    <!-- NOTE: The telephony module is no longer reading the configuration below for available
+         APN types.  The set of APN types and relevant settings are specified within the telephony
+         module and are non-configurable.  Whether or not data connectivity over a cellular network
+         is available at all is controlled by the flag: config_moble_data_capable. -->
+    <string-array name="networkAttributes">
+        <item>wifi,1,1,1,-1,true</item>
+        <item>mobile,0,0,0,-1,true</item>
+        <item>mobile_mms,2,0,2,240000,true</item>
+        <item>mobile_supl,3,0,2,60000,true</item>
+        <item>mobile_dun,4,0,2,60000,true</item>
+        <item>mobile_hipri,5,0,3,60000,true</item>
+        <item>bluetooth,7,7,0,-1,true</item>
+        <item>ethernet,9,9,2,-1,true</item>
+        <item>mobile_fota,10,0,2,60000,true</item>
+        <item>mobile_ims,11,0,1,-1,true</item>
+        <item>mobile_cbs,12,0,2,60000,true</item>
+        <item>wifi_p2p,13,1,0,-1,true</item>
+        <item>mobile_ia,14,0,2,-1,true</item>
+        <item>mobile_emergency,15,0,2,-1,true</item>
+        <item>mobile_bip,23,0,2,60000,true</item>
+        <item>mobile_cas,24,0,3,60000,true</item>
+        <item>mobile_xcap,27,0,2,60000,true</item>
+        <item>mobile_ent1,28,0,2,-1,true</item>
+        <item>mobile_mcx,32,0,2,-1,true</item>
+        <item>mobile_foc,30,0,2,-1,true</item>
+        <item>mobile_rcs,31,0,2,-1,true</item>
     </string-array>
-	<string-array name="config_tether_bluetooth_regexs">
-        <item>bt-pan</item>
-    </string-array>
-	<integer-array name="config_tether_upstream_types">
-        <item>1</item>
-        <item>7</item>
-        <item>0</item>
-    </integer-array>
 </resources>

--- a/Samsung/A20/res/values/bools.xml
+++ b/Samsung/A20/res/values/bools.xml
@@ -1,15 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
+    <!-- Whether the display cutout region of the main built-in display should be forced to
+         black in software (to avoid aliasing or emulate a cutout that is not physically existent).
+         -->
+    <bool name="config_fillMainBuiltInDisplayCutout">true</bool>
+
+    <!-- Whether a software navigation bar should be shown -->
     <bool name="config_showNavigationBar">true</bool>
-    <bool name="config_useDevInputEventForAudioJack">false</bool>
-    <bool name="config_enableBurnInProtection">false</bool>
-	<bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-	<bool name="config_dozePulsePickup">false</bool>
-	<bool name="config_automatic_brightness_available">true</bool>
-	<bool name="config_device_volte_available">true</bool>
-	<bool name="config_carrier_volte_available">true</bool>
-	<bool name="config_device_vt_available">true</bool>
-	<bool name="config_device_wfc_ims_available">true</bool>
-	<bool name="config_switch_phone_on_voice_reg_state_change">true</bool>
+
+    <!-- When true use the linux /dev/input/event subsystem to detect the switch changes
+         on the headphone/microphone jack. When false use the older uevent framework. -->
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+
+    <!-- Boolean indicating whether the wifi chipset has background scan support -->
+    <bool name="config_wifi_background_scan_support">true</bool>
+
+    <!-- True if the firmware supports connected MAC randomization -->
+    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
+
+    <!-- Boolean indicating whether the wifi chipset has dual frequency band support -->
+    <!-- The Galaxy A20 does support the 5GHz band, but it's disabled in the vendor wifi
+         configuration that is read in the kernel. Enabling it does work but 5GHz networks are 
+         unusable due to VERY low signal. -->
+    <!-- Also, this setting seems to have been renamed to config_wifi5ghzSupport -->
+    <!-- <bool name="config_wifi_dual_band_support">true</bool> -->
+
+    <!-- Boolean indicating whether 802.11r Fast BSS Transition is enabled on this platform -->
+    <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
 </resources>

--- a/Samsung/A20/res/values/bools.xml
+++ b/Samsung/A20/res/values/bools.xml
@@ -27,4 +27,9 @@
 
     <!-- Boolean indicating whether 802.11r Fast BSS Transition is enabled on this platform -->
     <bool name="config_wifi_fast_bss_transition_enabled">true</bool>
+
+    <!-- Control whether the always on display mode is available. This should only be enabled on
+         devices where the display has been tuned to be power efficient in DOZE and/or DOZE_SUSPEND
+         states. -->
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
 </resources>

--- a/Samsung/A20/res/values/dimens.xml
+++ b/Samsung/A20/res/values/dimens.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<dimen name="rounded_corner_radius">0.0dip</dimen>
-	<dimen name="status_bar_height_landscape">24.0dip</dimen>
-	<dimen name="status_bar_height_portrait">53px</dimen>
+    <!-- Radius of the software rounded corners. -->
+    <dimen name="rounded_corner_radius_bottom">100.73999px</dimen>
+    <dimen name="rounded_corner_radius_top">100.73999px</dimen>
+
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height_portrait">53.0px</dimen>
 </resources>

--- a/Samsung/A20/res/values/integers.xml
+++ b/Samsung/A20/res/values/integers.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer name="config_screenBrightnessDim">10</integer>
-    <integer name="config_screenBrightnessSettingDefault">102</integer>
+    <!-- Screen brightness used to dim the screen when the user activity
+         timeout expires.  May be less than the minimum allowed brightness setting
+         that can be set by the user. -->
+    <integer name="config_screenBrightnessDim">15</integer>
+
+    <!-- Default screen brightness setting.
+         Must be in the range specified by minimum and maximum. -->
+    <integer name="config_screenBrightnessSettingDefault">128</integer>
+
+    <!-- Maximum screen brightness allowed by the power manager.
+         The user is forbidden from setting the brightness above this level. -->
     <integer name="config_screenBrightnessSettingMaximum">255</integer>
-    <integer name="config_screenBrightnessSettingMinimum">10</integer>
-	<integer name="config_screenBrightnessDoze">1</integer>
+
+    <!-- Minimum screen brightness setting allowed by power manager.
+         The user is forbidden from setting the brightness below this level.  -->
+    <integer name="config_screenBrightnessSettingMinimum">0</integer>
 </resources>

--- a/Samsung/A20/res/values/strings.xml
+++ b/Samsung/A20/res/values/strings.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- The bounding path of the cutout region of the main built-in display.
+         Must either be empty if there is no cutout region, or a string that is parsable by
+         {@link android.util.PathParser}.
+
+         The path is assumed to be specified in display coordinates with pixel units and in
+         the display's native orientation, with the origin of the coordinate system at the
+         center top of the display. Optionally, you can append either `@left` or `@right` to the
+         end of the path string, in order to change the path origin to either the top left,
+         or top right of the display.
+
+         To facilitate writing device-independent emulation overlays, the marker `@dp` can be
+         appended after the path string to interpret coordinates in dp instead of px units.
+         Note that a physical cutout should be configured in pixels for the best results.
+
+         Example for a 10px x 10px square top-center cutout:
+                <string ...>M -5,0 L -5,10 L 5,10 L 5,0 Z</string>
+         Example for a 10dp x 10dp square top-center cutout:
+                <string ...>M -5,0 L -5,10 L 5,10 L 5,0 Z @dp</string>
+
+         @see https://www.w3.org/TR/SVG/paths.html#PathData
+         -->
     <string name="config_mainBuiltInDisplayCutout">M62,0l-3.8,0l-3.9,0.2l-3.9,0.4l-4,0.8l-3.9,1.2l-3.8,1.6l-3.7,2l-3.4,2.4l-3.1,2.8l-2.9,3l-2.7,3.1l-2.6,3.1 l-2.7,2.8C12.5,28,6.2,30.3,0,30.3c-6.3,0-12.5-2.3-17.5-6.8l-2.7-2.8l-2.6-3.1l-2.7-3.1l-2.9-3l-3.2-2.8 L-35,6.2l-3.7-2l-3.8-1.6l-3.9-1.2l-4-0.8L-54.3,0.2L-58.2,0L-62,0Z @dp</string>
 </resources>

--- a/Samsung/A20/res/xml/power_profile.xml
+++ b/Samsung/A20/res/xml/power_profile.xml
@@ -1,46 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
 <device name="Android">
-    <item name="ambient.on">0.1</item>
-    <item name="screen.on">0.1</item>
-    <item name="screen.full">0.1</item>
-    <item name="bluetooth.active">0.1</item>
-    <item name="bluetooth.on">0.1</item>
-    <item name="wifi.on">0.1</item>
-    <item name="wifi.active">0.1</item>
-    <item name="wifi.scan">0.1</item>
-    <item name="audio">0.1</item>
-    <item name="video">0.1</item>
-    <item name="camera.flashlight">0.1</item>
-    <item name="camera.avg">0.1</item>
-    <item name="gps.on">0.1</item>
-    <item name="radio.active">0.1</item>
-    <item name="radio.scanning">0.1</item>
+    <item name="none">0</item>
+    <item name="screen.on">93</item>
+    <item name="screen.full">313</item>
+    <item name="bluetooth.active">118</item>
+    <item name="bluetooth.on">0.98</item>
+    <item name="wifi.on">0.43</item>
+    <item name="wifi.active">488</item>
+    <item name="wifi.scan">502</item>
+    <item name="audio">45</item>
+    <item name="video">286</item>
+    <item name="camera.flashlight">124</item>
+    <item name="camera.avg">662</item>
+    <item name="gps.on">32</item>
+    <item name="radio.active">164</item>
+    <item name="radio.scanning">115</item>
     <array name="radio.on">
-        <value>0.2</value>
-        <value>0.1</value>
-    </array>
-    <array name="cpu.active">
-        <value>0.1</value>
+        <value>7.3</value>
+        <value>7.3</value>
     </array>
     <array name="cpu.clusters.cores">
-        <value>1</value>
+        <value>6</value>
+        <value>2</value>
     </array>
-    <array name="cpu.speeds.cluster0">
-        <value>400000</value>
+    <array name="cpu.core_speeds.cluster0">
+        <value>1586000</value>
+        <value>1482000</value>
+        <value>1352000</value>
+        <value>1248000</value>
+        <value>1144000</value>
+        <value>1014000</value>
+        <value>902000</value>
+        <value>839000</value>
+        <value>757000</value>
+        <value>676000</value>
+        <value>546000</value>
+        <value>449000</value>
     </array>
-    <array name="cpu.active.cluster0">
-        <value>0.1</value>
+    <array name="cpu.core_power.cluster0">
+        <value>50</value>
+        <value>43</value>
+        <value>34</value>
+        <value>28</value>
+        <value>24</value>
+        <value>18</value>
+        <value>15</value>
+        <value>13</value>
+        <value>11</value>
+        <value>10</value>
+        <value>7</value>
+        <value>6</value>
     </array>
-    <item name="cpu.idle">0.1</item>
-    <array name="memory.bandwidths">
-        <value>22.7</value>
+    <array name="cpu.core_speeds.cluster1">
+        <value>1768000</value>
+        <value>1664000</value>
+        <value>1560000</value>
+        <value>1352000</value>
+        <value>1144000</value>
+        <value>936000</value>
     </array>
-    <item name="battery.capacity">1000</item>
-    <item name="wifi.controller.idle">0</item>
-    <item name="wifi.controller.rx">0</item>
-    <item name="wifi.controller.tx">0</item>
-    <array name="wifi.controller.tx_levels" />
-    <item name="wifi.controller.voltage">0</item>
+    <array name="cpu.core_power.cluster1">
+        <value>162</value>
+        <value>142</value>
+        <value>120</value>
+        <value>87</value>
+        <value>61</value>
+        <value>41</value>
+    </array>
+    <item name="cpu.suspend">3.79</item>
+    <item name="cpu.idle">23</item>
+    <item name="battery.capacity">3900</item>
+    <item name="battery.typical.capacity">4000</item>
+    <item name="wifi.controller.idle">1</item>
+    <item name="wifi.controller.rx">65</item>
+    <item name="wifi.controller.tx">265</item>
+    <array name="wifi.controller.tx_levels">
+        <value>0</value>
+    </array>
+    <item name="wifi.controller.voltage">3600</item>
     <array name="wifi.batchedscan">
         <value>.0002</value>
         <value>.002</value>
@@ -48,20 +85,4 @@
         <value>.2</value>
         <value>2</value>
     </array>
-    <item name="modem.controller.sleep">0</item>
-    <item name="modem.controller.idle">0</item>
-    <item name="modem.controller.rx">0</item>
-    <array name="modem.controller.tx">
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
-    </array>
-    <item name="modem.controller.voltage">0</item>
-    <array name="gps.signalqualitybased">
-        <value>0</value>
-        <value>0</value>
-    </array>
-    <item name="gps.voltage">0</item>
 </device>


### PR DESCRIPTION
Previous overlay (from tristanbollard) broke wired headphones and battery usage, so i redid it from scratch using the overlay located in the stock R Vendor.

Notes:
- I wasn't able to get the Auto Brightness to work so i didn't bother enabling it (wasn't working with the previous overlay either)
- Previous overlay set some VoLTE-related values. I don't know if they do anything or not as i can't test VoLTE, so didn't bother adding them either.