### PR TITLE
Lenovo: K5Pro: Use ro.vendor.build.fingerprint as overlay target

### DIFF
--- a/Lenovo/K5Pro/AndroidManifest.xml
+++ b/Lenovo/K5Pro/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.vendor.product.model"
-                android:requiredSystemPropertyValue="Lenovo L38041"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+Lenovo/kunlun/kunlun*"
 		android:priority="70"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Since Android 9 OEM update, `ro.vendor.product.model` on Android 8.1 vendor was replaced by `ro.product.vendor.model`. Replacing it with `ro.vendor.build.fingerprint` to make device recognized by the overlay.