### PR TITLE
Add 4G variant compatibility from Stylo 5G overlay

### DIFF
--- a/LG/mfh505glm-SystemUI/AndroidManifest.xml
+++ b/LG/mfh505glm-SystemUI/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="com.android.systemui"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="mfh505glm"
+                android:requiredSystemPropertyValue="+(mfh505glm|fh50lm)"
         android:priority="505"
         android:isStatic="true" />
 </manifest>

--- a/LG/mfh505glm/AndroidManifest.xml
+++ b/LG/mfh505glm/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="mfh505glm"
+                android:requiredSystemPropertyValue="+(mfh505glm|fh50lm)"
         android:priority="505"
         android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Added fh50lm (LG Stylo 7 4G) to use the overlay of Stylo 5G together. Since the two devices have the same display, they work well.