### PR TITLE
S20FE: Fix Status bar on landscape+Add cutout values

### DIFF
--- a/Samsung/S20fe/res/values-land/config.xml
+++ b/Samsung/S20fe/res/values-land/config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="status_bar_height">26.0dp</dimen>
-</resources>

--- a/Samsung/S20fe/res/values/config.xml
+++ b/Samsung/S20fe/res/values/config.xml
@@ -1053,8 +1053,9 @@
 
     <dimen name="status_bar_height">92.0px</dimen>
     <dimen name="status_bar_height_portrait">92.0px</dimen>
-    <dimen name="status_bar_height_landscape">26.0dp</dimen>
 	  <dimen name="quick_qs_offset_height">@dimen/status_bar_height_portrait</dimen>
 
     <integer name="config_screenBrightnessSettingMinimum">0</integer>
+
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 M 0,12.25101276465640 a 10.60613009248640,10.60613009248640 0 1,0 0,21.21226018497290 a 10.60613009248640,10.60613009248640 0 1,0 0,-21.21226018497290 Z @dp</string>
 </resources>


### PR DESCRIPTION
Removed status_bar_height_landscape attribute and values-land. This fixes Status bar height on Landscape mode. Added cutout values so that Full screen apps aren't covering the camera in Landscape