### PR TITLE
Add SystemUI overlay for Samsung M31

### DIFF
--- a/Samsung/M31-SystemUI/Android.mk
+++ b/Samsung/M31-SystemUI/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-samsung-m31-systemui
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Samsung/M31-SystemUI/AndroidManifest.xml
+++ b/Samsung/M31-SystemUI/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.samsung.m31.systemui"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.systemui"
+        	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+        	android:requiredSystemPropertyValue="+*samsung/m31*"
+		android:priority="346"
+		android:isStatic="true" />
+</manifest>

--- a/Samsung/M31-SystemUI/res/values/config.xml
+++ b/Samsung/M31-SystemUI/res/values/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_padding_start">25px</dimen>
+    <dimen name="status_bar_padding_end">25px</dimen>
+    <dimen name="status_bar_header_height_keyguard">35dp</dimen>
+    <dimen name="keyguard_carrier_text_margin">45px</dimen>
+    <dimen name="system_icons_keyguard_padding_end">45px</dimen>
+    <dimen name="rounded_corner_content_padding">4dp</dimen>
+    <dimen name="physical_power_button_center_screen_location_y">864px</dimen>
+</resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -164,6 +164,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-gts7xllite \
 	treble-overlay-samsung-j6 \
 	treble-overlay-samsung-m31 \
+	treble-overlay-samsung-m31-systemui \
 	treble-overlay-samsung-m31s \
 	treble-overlay-samsung-n9q \
 	treble-overlay-samsung-o1s \


### PR DESCRIPTION
This helps with aligning the status bar correctly with the notch and properly positioning the power-off animation with the power button.