### PR TITLE
[Redmi Note 10S] Add SystemUI Overlays and Padding adjustment

### DIFF
--- a/Xiaomi/RedmiNote10S-SystemUI/Android.mk
+++ b/Xiaomi/RedmiNote10S-SystemUI/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-redminote10s-systemui
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/RedmiNote10S-SystemUI/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote10S-SystemUI/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="com.android.systemui"
-                android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="+(rosemary|secret|maltose)"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+(*edmi/rosemary*|*edmi/secret*|*edmi/maltose*)"
 		android:priority="934"
 		android:isStatic="true" />
 </manifest>

--- a/Xiaomi/RedmiNote10S-SystemUI/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote10S-SystemUI/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.redminote10s.systemui"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.systemui"
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="+(rosemary|secret|maltose)"
+		android:priority="934"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/RedmiNote10S-SystemUI/res/values-v31/config.xml
+++ b/Xiaomi/RedmiNote10S-SystemUI/res/values-v31/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="physical_power_button_center_screen_location_y">1035px</dimen>
+</resources>

--- a/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
+++ b/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
@@ -6,5 +6,4 @@
     <dimen name="keyguard_carrier_text_margin">4.5dp</dimen>
     <dimen name="system_icons_keyguard_padding_end">4.5dp</dimen>
     <dimen name="rounded_corner_content_padding">52.0px</dimen>
-    <dimen name="physical_power_button_center_screen_location_y">1035px</dimen>
 </resources>

--- a/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
+++ b/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_padding_start">4.5dp</dimen>
+    <dimen name="status_bar_padding_end">4.5dp</dimen>
+    <dimen name="status_bar_header_height_keyguard">93px</dimen>
+    <dimen name="keyguard_carrier_text_margin">4.5dp</dimen>
+    <dimen name="system_icons_keyguard_padding_end">4.5dp</dimen>
+    <dimen name="rounded_corner_content_padding">52.0px</dimen>
+</resources>

--- a/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
+++ b/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
@@ -6,5 +6,5 @@
     <dimen name="keyguard_carrier_text_margin">4.5dp</dimen>
     <dimen name="system_icons_keyguard_padding_end">4.5dp</dimen>
     <dimen name="rounded_corner_content_padding">52.0px</dimen>
-    <dimen name="physical_power_button_center_screen_location_y">1045px</dimen>
+    <dimen name="physical_power_button_center_screen_location_y">1035px</dimen>
 </resources>

--- a/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
+++ b/Xiaomi/RedmiNote10S-SystemUI/res/values/config.xml
@@ -6,4 +6,5 @@
     <dimen name="keyguard_carrier_text_margin">4.5dp</dimen>
     <dimen name="system_icons_keyguard_padding_end">4.5dp</dimen>
     <dimen name="rounded_corner_content_padding">52.0px</dimen>
+    <dimen name="physical_power_button_center_screen_location_y">1045px</dimen>
 </resources>

--- a/Xiaomi/RedmiNote10S/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote10S/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.product.vendor.device"
-                android:requiredSystemPropertyValue="+(rosemary|secret|maltose)"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+(*edmi/rosemary*|*edmi/secret*|*edmi/maltose*)"
 		android:priority="671"
 		android:isStatic="true" />
 </manifest>

--- a/overlay.mk
+++ b/overlay.mk
@@ -243,6 +243,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redmik20pro-systemui \
 	treble-overlay-xiaomi-redminote10pro \
 	treble-overlay-xiaomi-redminote10s \
+	treble-overlay-xiaomi-redminote10s-systemui \
 	treble-overlay-xiaomi-redminote11 \
 	treble-overlay-xiaomi-redminote5 \
 	treble-overlay-xiaomi-redminote6pro \


### PR DESCRIPTION
I added SystemUI overlays support all variant of Redmi Note 10S. adjust padding based on DeviceOverlay from Vendor put some minor tweaks to fit Android 12, and lastly align the power button location