### PR TITLE
Sony pdx206: Use correct power_profile from stock

### DIFF
--- a/Sony/pdx206/res/xml/power_profile.xml
+++ b/Sony/pdx206/res/xml/power_profile.xml
@@ -1,46 +1,162 @@
 <?xml version="1.0" encoding="utf-8"?>
 <device name="Android">
-    <item name="ambient.on">0.1</item>
-    <item name="screen.on">0.1</item>
-    <item name="screen.full">0.1</item>
-    <item name="bluetooth.active">0.1</item>
-    <item name="bluetooth.on">0.1</item>
-    <item name="wifi.on">0.1</item>
-    <item name="wifi.active">0.1</item>
-    <item name="wifi.scan">0.1</item>
-    <item name="audio">0.1</item>
-    <item name="video">0.1</item>
-    <item name="camera.flashlight">0.1</item>
-    <item name="camera.avg">0.1</item>
-    <item name="gps.on">0.1</item>
-    <item name="radio.active">0.1</item>
-    <item name="radio.scanning">0.1</item>
+    <item name="ambient.on">75.00</item>
+    <item name="screen.on">140.01</item>
+    <item name="screen.full">381.95</item>
+    <item name="bluetooth.active">0</item>
+    <item name="bluetooth.on">0</item>
+    <item name="wifi.on">9.27</item>
+    <item name="wifi.active">73.48</item>
+    <item name="wifi.scan">65.64</item>
+    <item name="audio">23.49</item>
+    <item name="video">47.08</item>
+    <item name="camera.flashlight">27.98</item>
+    <item name="camera.avg">405.69</item>
+    <item name="radio.active">137.50</item>
+    <item name="radio.scanning">105.40</item>
     <array name="radio.on">
-        <value>0.2</value>
-        <value>0.1</value>
-    </array>
-    <array name="cpu.active">
-        <value>0.1</value>
+        <value>5.76</value>
+        <value>5.76</value>
+        <value>5.76</value>
+        <value>5.76</value>
+        <value>5.76</value>
     </array>
     <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>3</value>
         <value>1</value>
     </array>
-    <array name="cpu.speeds.cluster0">
-        <value>400000</value>
+    <array name="cpu.core_speeds.cluster0">
+        <value>300000</value>
+        <value>403200</value>
+        <value>518400</value>
+        <value>614400</value>
+        <value>691200</value>
+        <value>787200</value>
+        <value>883200</value>
+        <value>979200</value>
+        <value>1075200</value>
+        <value>1171200</value>
+        <value>1248000</value>
+        <value>1344000</value>
+        <value>1420800</value>
+        <value>1516800</value>
+        <value>1612800</value>
+        <value>1708800</value>
+        <value>1804800</value>
     </array>
-    <array name="cpu.active.cluster0">
-        <value>0.1</value>
+    <array name="cpu.core_speeds.cluster1">
+        <value>710400</value>
+        <value>825600</value>
+        <value>940800</value>
+        <value>1056000</value>
+        <value>1171200</value>
+        <value>1286400</value>
+        <value>1382400</value>
+        <value>1478400</value>
+        <value>1574400</value>
+        <value>1670400</value>
+        <value>1766400</value>
+        <value>1862400</value>
+        <value>1958400</value>
+        <value>2054400</value>
+        <value>2150400</value>
+        <value>2246400</value>
+        <value>2342400</value>
+        <value>2419200</value>
     </array>
-    <item name="cpu.idle">0.1</item>
-    <array name="memory.bandwidths">
-        <value>22.7</value>
+    <array name="cpu.core_speeds.cluster2">
+        <value>844800</value>
+        <value>960000</value>
+        <value>1075200</value>
+        <value>1190400</value>
+        <value>1305600</value>
+        <value>1401600</value>
+        <value>1516800</value>
+        <value>1632000</value>
+        <value>1747200</value>
+        <value>1862400</value>
+        <value>1977600</value>
+        <value>2073600</value>
+        <value>2169600</value>
+        <value>2265600</value>
+        <value>2361600</value>
+        <value>2457600</value>
+        <value>2553600</value>
+        <value>2649600</value>
+        <value>2745600</value>
+        <value>2841600</value>
     </array>
-    <item name="battery.capacity">1000</item>
-    <item name="wifi.controller.idle">0</item>
-    <item name="wifi.controller.rx">0</item>
-    <item name="wifi.controller.tx">0</item>
+    <array name="cpu.core_power.cluster0">
+        <value>5.77</value>
+        <value>6.08</value>
+        <value>6.42</value>
+        <value>6.55</value>
+        <value>6.81</value>
+        <value>7.61</value>
+        <value>8.06</value>
+        <value>8.53</value>
+        <value>8.81</value>
+        <value>9.28</value>
+        <value>10.22</value>
+        <value>11.39</value>
+        <value>12.55</value>
+        <value>13.83</value>
+        <value>14.72</value>
+        <value>15.86</value>
+        <value>17.09</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>8.25</value>
+        <value>10.04</value>
+        <value>11.72</value>
+        <value>13.49</value>
+        <value>15.53</value>
+        <value>17.90</value>
+        <value>19.48</value>
+        <value>21.75</value>
+        <value>23.95</value>
+        <value>26.67</value>
+        <value>31.95</value>
+        <value>37.68</value>
+        <value>39.27</value>
+        <value>42.82</value>
+        <value>46.44</value>
+        <value>50.93</value>
+        <value>55.65</value>
+        <value>59.25</value>
+    </array>
+    <array name="cpu.core_power.cluster2">
+        <value>26.55</value>
+        <value>31.09</value>
+        <value>35.73</value>
+        <value>40.47</value>
+        <value>45.01</value>
+        <value>48.99</value>
+        <value>56.40</value>
+        <value>64.44</value>
+        <value>73.14</value>
+        <value>81.45</value>
+        <value>92.60</value>
+        <value>104.67</value>
+        <value>119.90</value>
+        <value>124.54</value>
+        <value>131.61</value>
+        <value>144.12</value>
+        <value>158.46</value>
+        <value>171.97</value>
+        <value>183.45</value>
+        <value>194.23</value>
+    </array>
+    <item name="cpu.suspend">4.68</item>
+    <item name="cpu.idle">6.00</item>
+    <item name="cpu.active">0.01</item>
+    <item name="battery.capacity">3860</item>
+    <item name="wifi.controller.idle">0.00</item>
+    <item name="wifi.controller.rx">5.55</item>
+    <item name="wifi.controller.tx">6.70</item>
     <array name="wifi.controller.tx_levels" />
-    <item name="wifi.controller.voltage">0</item>
+    <item name="wifi.controller.voltage">600.00</item>
     <array name="wifi.batchedscan">
         <value>.0002</value>
         <value>.002</value>
@@ -48,20 +164,23 @@
         <value>.2</value>
         <value>2</value>
     </array>
-    <item name="modem.controller.sleep">0</item>
-    <item name="modem.controller.idle">0</item>
-    <item name="modem.controller.rx">0</item>
+    <item name="modem.controller.idle">0.67</item>
+    <item name="modem.controller.rx">116.96</item>
     <array name="modem.controller.tx">
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
+        <value>112.33</value>
+        <value>112.33</value>
+        <value>112.33</value>
+        <value>112.33</value>
+        <value>112.33</value>
     </array>
-    <item name="modem.controller.voltage">0</item>
+    <item name="modem.controller.voltage">580</item>
+    <item name="bluetooth.controller.idle">0.59</item>
+    <item name="bluetooth.controller.rx">66.68</item>
+    <item name="bluetooth.controller.tx">77.97</item>
+    <item name="bluetooth.controller.voltage">3800.00</item>
     <array name="gps.signalqualitybased">
-        <value>0</value>
-        <value>0</value>
+        <value>47.39</value>
+        <value>11.94</value>
     </array>
-    <item name="gps.voltage">0</item>
+    <item name="gps.voltage">3800</item>
 </device>


### PR DESCRIPTION
I've experienced one completely weird bug with GSIs on my Xperia 5 II (pdx206) depending on battery, which have shown wrong capacities (something around 3000mAh and 3200mAh).

On hardware side, it's 4000mAh, but Sony seems to limit it to 3860mAh, maybe for battery protection. We should keep it as stock like as is. Also the cluster config was wrong because we use the 4-3-1 core scheme.

So this pr should implement the right power_profile for pdx206 devices.