### PR TITLE
Miscellaneous fixes for Sony Xperia 5 II (pdx206)

### DIFF
--- a/Sony/pdx206/res/values/config.xml
+++ b/Sony/pdx206/res/values/config.xml
@@ -44,7 +44,7 @@
     <integer name="config_defaultPeakRefreshRate">0</integer>
     <integer name="config_screenBrightnessDark">1</integer>
     <integer name="config_screenBrightnessDim">10</integer>
-    <integer name="config_screenBrightnessDoze">1</integer>
+    <integer name="config_screenBrightnessDoze">10</integer>
     <integer name="config_screenBrightnessForVrSettingDefault">86</integer>
     <integer name="config_screenBrightnessForVrSettingMaximum">255</integer>
     <integer name="config_screenBrightnessForVrSettingMinimum">79</integer>
@@ -88,4 +88,5 @@
     <bool name="config_hotswapCapable">true</bool>
     <bool name="config_enableBurnInProtection">true</bool>
     <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
 </resources>

--- a/Sony/pdx206/res/values/config.xml
+++ b/Sony/pdx206/res/values/config.xml
@@ -44,7 +44,7 @@
     <integer name="config_defaultPeakRefreshRate">0</integer>
     <integer name="config_screenBrightnessDark">1</integer>
     <integer name="config_screenBrightnessDim">10</integer>
-    <integer name="config_screenBrightnessDoze">10</integer>
+    <integer name="config_screenBrightnessDoze">5</integer>
     <integer name="config_screenBrightnessForVrSettingDefault">86</integer>
     <integer name="config_screenBrightnessForVrSettingMaximum">255</integer>
     <integer name="config_screenBrightnessForVrSettingMinimum">79</integer>

--- a/Sony/pdx206/res/xml/power_profile.xml
+++ b/Sony/pdx206/res/xml/power_profile.xml
@@ -1,46 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
 <device name="Android">
-    <item name="ambient.on">0.1</item>
-    <item name="screen.on">0.1</item>
-    <item name="screen.full">0.1</item>
+    <item name="ambient.on">41.4</item>
+    <item name="screen.on">59.29</item>
+    <item name="screen.full">190.00</item>
     <item name="bluetooth.active">0.1</item>
-    <item name="bluetooth.on">0.1</item>
-    <item name="wifi.on">0.1</item>
-    <item name="wifi.active">0.1</item>
-    <item name="wifi.scan">0.1</item>
-    <item name="audio">0.1</item>
-    <item name="video">0.1</item>
-    <item name="camera.flashlight">0.1</item>
-    <item name="camera.avg">0.1</item>
-    <item name="gps.on">0.1</item>
-    <item name="radio.active">0.1</item>
-    <item name="radio.scanning">0.1</item>
+    <item name="bluetooth.on">0.8</item>
+    <item name="wifi.on">5.00</item>
+    <item name="wifi.active">35.84</item>
+    <item name="wifi.scan">87.99</item>
+    <item name="audio">20.52</item>
+    <item name="video">159.96</item>
+    <item name="camera.flashlight">62.56</item>
+    <item name="camera.avg">573.58</item>
+    <item name="radio.active">108.48</item>
+    <item name="radio.scanning">24.74</item>
     <array name="radio.on">
-        <value>0.2</value>
-        <value>0.1</value>
-    </array>
-    <array name="cpu.active">
-        <value>0.1</value>
+        <value>4.68</value>
+        <value>4.68</value>
+        <value>4.68</value>
+        <value>4.68</value>
+        <value>4.68</value>
     </array>
     <array name="cpu.clusters.cores">
-        <value>1</value>
+        <value>4</value>
+        <value>4</value>
     </array>
-    <array name="cpu.speeds.cluster0">
-        <value>400000</value>
+    <array name="cpu.core_speeds.cluster0">
+        <value>300000.0</value>
+        <value>614400.0</value>
+        <value>864000.0</value>
+        <value>1017600.0</value>
+        <value>1305600.0</value>
+        <value>1420800.0</value>
+        <value>1612800.0</value>
+        <value>1804800.0</value>
     </array>
-    <array name="cpu.active.cluster0">
-        <value>0.1</value>
+    <array name="cpu.core_speeds.cluster1">
+        <value>300000.0</value>
+        <value>652800.0</value>
+        <value>902400.0</value>
+        <value>1056000.0</value>
+        <value>1401060.0</value>
+        <value>1536000.0</value>
+        <value>1804800.0</value>
+        <value>2016000.0</value>
     </array>
-    <item name="cpu.idle">0.1</item>
+    <array name="cpu.core_power.cluster0">
+        <value>30.87</value>
+        <value>30.99</value>
+        <value>31.93</value>
+        <value>32.14</value>
+        <value>36.22</value>
+        <value>40.38</value>
+        <value>44.19</value>
+        <value>50.58</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>38.14</value>
+        <value>38.38</value>
+        <value>38.98</value>
+        <value>40.36</value>
+        <value>49.39</value>
+        <value>54.23</value>
+        <value>68.45</value>
+        <value>81.50</value>
+    </array>
+    <item name="cpu.suspend">2.90</item>
+    <item name="cpu.idle">28.88</item>
+    <item name="cpu.active">0.01</item>
     <array name="memory.bandwidths">
         <value>22.7</value>
     </array>
-    <item name="battery.capacity">1000</item>
-    <item name="wifi.controller.idle">0</item>
-    <item name="wifi.controller.rx">0</item>
-    <item name="wifi.controller.tx">0</item>
+    <item name="battery.capacity">3460</item>
+    <item name="wifi.controller.idle">0.19</item>
+    <item name="wifi.controller.rx">148.18</item>
+    <item name="wifi.controller.tx">395.03</item>
     <array name="wifi.controller.tx_levels" />
-    <item name="wifi.controller.voltage">0</item>
+    <item name="wifi.controller.voltage">3700</item>
     <array name="wifi.batchedscan">
         <value>.0002</value>
         <value>.002</value>
@@ -49,19 +85,23 @@
         <value>2</value>
     </array>
     <item name="modem.controller.sleep">0</item>
-    <item name="modem.controller.idle">0</item>
-    <item name="modem.controller.rx">0</item>
+    <item name="modem.controller.idle">0.22</item>
+    <item name="modem.controller.rx">84.82</item>
     <array name="modem.controller.tx">
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
-        <value>0</value>
+        <value>84.19</value>
+        <value>84.19</value>
+        <value>84.19</value>
+        <value>84.19</value>
+        <value>84.19</value>
     </array>
-    <item name="modem.controller.voltage">0</item>
+    <item name="modem.controller.voltage">620</item>
+    <item name="bluetooth.controller.idle">0</item>
+    <item name="bluetooth.controller.rx">66.01</item>
+    <item name="bluetooth.controller.tx">71.79</item>
+    <item name="bluetooth.controller.voltage">3700</item>
     <array name="gps.signalqualitybased">
-        <value>0</value>
-        <value>0</value>
+        <value>58.28</value>
+        <value>12.49</value>
     </array>
-    <item name="gps.voltage">0</item>
+    <item name="gps.voltage">3.70</item>
 </device>

--- a/Sony/pdx206_kddi/Android.mk
+++ b/Sony/pdx206_kddi/Android.mk
@@ -1,0 +1,9 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-sony-pdx206-kddi
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_RESOURCE_DIR := $(LOCAL_PATH)/../pdx206/res
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Sony/pdx206_kddi/AndroidManifest.xml
+++ b/Sony/pdx206_kddi/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="me.phh.treble.overlay.sony.pdx206" android:versionCode="1" android:versionName="1.0">
+    <overlay android:targetPackage="android" android:requiredSystemPropertyName="ro.vendor.build.fingerprint" android:requiredSystemPropertyValue="+KDDI/pdx206_kddi/pdx206_kddi*" android:priority="454" android:isStatic="true" />
+</manifest>

--- a/Sony/pdx206_kddi/AndroidManifest.xml
+++ b/Sony/pdx206_kddi/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="me.phh.treble.overlay.sony.pdx206" android:versionCode="1" android:versionName="1.0">
-    <overlay android:targetPackage="android" android:requiredSystemPropertyName="ro.vendor.build.fingerprint" android:requiredSystemPropertyValue="+KDDI/pdx206_kddi/pdx206_kddi*" android:priority="454" android:isStatic="true" />
+    <overlay android:targetPackage="android" android:requiredSystemPropertyName="ro.vendor.build.fingerprint" android:requiredSystemPropertyValue="+KDDI/pdx206_kddi/pdx206_kddi*" android:priority="1830" android:isStatic="true" />
 </manifest>

--- a/Sony/pdx206_kddi/res/values/config.xml
+++ b/Sony/pdx206_kddi/res/values/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Most configuration options are specified in the pdx206 overlay -->
+</resources>

--- a/overlay.mk
+++ b/overlay.mk
@@ -188,6 +188,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-sony-J9110 \
 	treble-overlay-sony-XZ3 \
 	treble-overlay-sony-pdx206 \
+	treble-overlay-sony-pdx206-kddi \
 	treble-overlay-sony-pdx213 \
 	treble-overlay-sony-pdx213-systemui \
 	treble-overlay-sprd-ims \


### PR DESCRIPTION
- Added an overlay for pdx206_kddi, the au (KDDI) variant of Sony Xperia 5 II. It shares the common configuration as the pdx206 target except the fingerprint matching rule.
- Enabled AOD support with an increased AOD brightness for legibility.
- A proper `power_profile` was imported. The previous one was just the dummy version shipped in AOSP by default.