### PR TITLE
Update A51 and A51 Systemui overlays

### DIFF
--- a/Samsung/A51-SystemUI/res/values/config.xml
+++ b/Samsung/A51-SystemUI/res/values/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="status_bar_padding_start">40px</dimen>
-    <dimen name="status_bar_padding_end">40px</dimen>
-    <dimen name="status_bar_padding_top">35px</dimen>
+    <dimen name="status_bar_padding_end">8px</dimen>
+    <dimen name="status_bar_padding_top">20px</dimen>
 </resources>

--- a/Samsung/A51/res/values/config.xml
+++ b/Samsung/A51/res/values/config.xml
@@ -637,4 +637,8 @@
      <bool name="config_automatic_brightness_available">true</bool>
      <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
      <bool name="config_supportDoubleTapWake">true</bool>
+
+     <dimen name="status_bar_height_portrait">84.0px</dimen>
+     <dimen name="status_bar_height_landscape">84.0px</dimen>
+
 </resources>


### PR DESCRIPTION
While these overlays did work fine on A12, the status bar icons are badly clipped off and unsymmetrically distributed on A12L.