### PR TITLE
add overlay for lenovo p11 (j606*)

### DIFF
--- a/Lenovo/J606/Android.mk
+++ b/Lenovo/J606/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-lenovo-j606
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Lenovo/J606/AndroidManifest.xml
+++ b/Lenovo/J606/AndroidManifest.xml
@@ -3,7 +3,7 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
                 android:requiredSystemPropertyValue="+*/J606*"
         android:priority="980"
         android:isStatic="true" />

--- a/Lenovo/J606/AndroidManifest.xml
+++ b/Lenovo/J606/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.lenovo.j606"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="+*/J606*"
+        android:priority="980"
+        android:isStatic="true" />
+</manifest>

--- a/Lenovo/J606/res/values/configs.xml
+++ b/Lenovo/J606/res/values/configs.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="config_lidControlsSleep">true</bool>
+  <bool name="config_automatic_brightness_available">true</bool>
+  <bool name="config_allowAutoBrightnessWhileDozing">false</bool>
+<integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>26</item>
+        <item>26</item>
+        <item>64</item>
+        <item>96</item>
+        <item>191</item>
+        <item>255</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>10</item>
+        <item>60</item>
+        <item>210</item>
+        <item>350</item>
+        <item>420</item>
+        <item>1000</item>
+    </integer-array>
+  <integer name="config_screenBrightnessSettingDefault">100</integer>
+  <integer name="config_screenBrightnessSettingMaximum">255</integer>
+  <integer name="config_screenBrightnessSettingMinimum">1</integer>
+  <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
+  <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
+  <integer name="config_shutdownBatteryTemperature">600</integer>
+</resources>

--- a/Lenovo/J606/res/xml/power_profile.xml
+++ b/Lenovo/J606/res/xml/power_profile.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">46</item>
+    <item name="screen.full">350</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>614000</value>
+        <value>864000</value>
+        <value>1017600</value>
+        <value>1305600</value>
+        <value>1420800</value>
+        <value>1612800</value>
+        <value>1804800</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>9</value>
+        <value>14</value>
+        <value>17</value>
+        <value>25</value>
+        <value>30</value>
+        <value>37</value>
+        <value>49</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>1056000</value>
+        <value>1401600</value>
+        <value>1536000</value>
+        <value>1612800</value>
+        <value>1804800</value>
+        <value>2016000</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>43</value>
+        <value>67</value>
+        <value>77</value>
+        <value>86</value>
+        <value>108</value>
+        <value>137</value>
+    </array>
+    <item name="cpu.active">18.3</item>
+    <item name="cpu.idle">2.9</item>
+    <item name="cpu.suspend">0</item>
+    <item name="battery.capacity">7700</item>
+    <item name="wifi.on">0.1</item>
+    <item name="wifi.active">148</item>
+    <item name="wifi.scan">1.2</item>
+    <item name="dsp.audio">21</item>
+    <item name="dsp.video">82</item>
+    <item name="camera.flashlight">530</item>
+    <item name="camera.avg">320</item>
+    <item name="gps.on">6.8</item>
+    <item name="radio.active">173</item>
+    <item name="radio.scanning">4.4</item>
+    <array name="radio.on">
+        <value>85</value>
+        <value>8.5</value>
+    </array>
+    <item name="modem.controller.idle">4.4</item>
+    <item name="modem.controller.rx">168</item>
+    <item name="modem.controller.tx">163</item>
+    <item name="modem.controller.voltage">3700</item>
+    <array name="memory.bandwidths">
+        <value>13.5</value>
+    </array>
+    <item name="wifi.controller.idle">1.22</item>
+    <item name="wifi.controller.rx">121</item>
+    <item name="wifi.controller.tx">156</item>
+    <array name="wifi.controller.tx_levels">1 </array>
+    <item name="wifi.controller.voltage">3700</item>
+    <array name="wifi.batchedscan">
+        <value>.0001</value>
+        <value>.001</value>
+        <value>.01</value>
+        <value>.1</value>
+        <value>1</value>
+    </array>
+    <item name="bluetooth.active">120</item>
+    <item name="bluetooth.on">1</item>
+    <item name="bluetooth.controller.voltage">3700</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -52,6 +52,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-infinix-note8 \
 	treble-overlay-infinix-s4 \
 	treble-overlay-infinix-zero6 \
+	treble-overlay-lenovo-j606 \
 	treble-overlay-lenovo-k5pro \
 	treble-overlay-lenovo-s5 \
 	treble-overlay-lenovo-s5pro \


### PR DESCRIPTION
tested on GSI LOS19.1

theare are to many p11 variations, so I named dir J606, and fingerprint */J606* have no conflicts.