### PR TITLE
Add wifi mac randomization for Samsung Galaxy A53

### DIFF
--- a/Samsung/A53/res/values/configs.xml
+++ b/Samsung/A53/res/values/configs.xml
@@ -495,7 +495,9 @@
     <bool name="config_device_volte_available">true</bool>
     <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
     <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_wifi_connected_mac_randomization_supported">true</bool>
     <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
     <bool name="config_useDevInputEventForAudioJack">true</bool>
     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
     <bool name="config_supportDoubleTapWake">true</bool>


### PR DESCRIPTION
Setting **not tested** on real device yet, but standard root/adb MAC address change works, so no reason to not include this for more privacy (unless this setting is known to break things).