### PR TITLE
A51 : Bottom-Align status bar icons again

### DIFF
--- a/Samsung/A51-SystemUI/res/values/config.xml
+++ b/Samsung/A51-SystemUI/res/values/config.xml
@@ -2,5 +2,5 @@
 <resources>
     <dimen name="status_bar_padding_start">40px</dimen>
     <dimen name="status_bar_padding_end">8px</dimen>
-    <dimen name="status_bar_padding_top">20px</dimen>
+    <dimen name="status_bar_padding_top">35px</dimen>
 </resources>

--- a/Samsung/A51/res/values/config.xml
+++ b/Samsung/A51/res/values/config.xml
@@ -638,6 +638,7 @@
      <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
      <bool name="config_supportDoubleTapWake">true</bool>
 
+     <dimen name="status_bar_height_default">84.0px</dimen>
      <dimen name="status_bar_height_portrait">84.0px</dimen>
      <dimen name="status_bar_height_landscape">84.0px</dimen>
 


### PR DESCRIPTION
- Set status_bar_height_default in addition to
  portrait and landscape height. (Thanks @AndyCGYan)
- Set status_bar_padding_top back to 35 to bottom align the icons