### PR TITLE
V2026: Fix statusbar padding on Android 12

### DIFF
--- a/Vivo/Y20-SystemUI/res/values/configs.xml
+++ b/Vivo/Y20-SystemUI/res/values/configs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<dimen name="status_bar_padding_start">30px</dimen>
-	<dimen name="status_bar_padding_end">30px</dimen>
+	<dimen name="status_bar_padding_end">10px</dimen>
 	<dimen name="status_bar_header_height_keyguard">24.0dip</dimen>
 </resources>

--- a/Vivo/Y20/res/values-land/configs.xml
+++ b/Vivo/Y20/res/values-land/configs.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="status_bar_height">24.0dip</dimen>
-    <dimen name="quick_qs_offset_height">24.0dip</dimen>
-</resources>

--- a/Vivo/Y20/res/values/configs.xml
+++ b/Vivo/Y20/res/values/configs.xml
@@ -1,12 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 		<bool name="config_automatic_brightness_available">true</bool>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+      <item>8</item>
+      <item>64</item>
+      <item>98</item>
+      <item>104</item>
+      <item>110</item>
+      <item>116</item>
+      <item>122</item>
+      <item>128</item>
+      <item>134</item>
+      <item>182</item>
+      <item>255</item>
+      <item>255</item>
+      <item>255</item>
+      <item>255</item>
+      <item>255</item>
+      <item>255</item>
+      <item>255</item>
+      <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+      <item>128</item>
+      <item>256</item>
+      <item>384</item>
+      <item>512</item>
+      <item>640</item>
+      <item>768</item>
+      <item>896</item>
+      <item>1024</item>
+      <item>2048</item>
+      <item>4096</item>
+      <item>6144</item>
+      <item>8192</item>
+      <item>10240</item>
+      <item>12288</item>
+      <item>14336</item>
+      <item>16384</item>
+      <item>18432</item>
+    </integer-array>
 		<bool name="config_showNavigationBar">true</bool>
 		<bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
 		<bool name="config_supportDoubleTapWake">true</bool>
 
-    <dimen name="status_bar_height">24.0dip</dimen>
-    <dimen name="status_bar_height_portrait">24.0dip</dimen>
-    <dimen name="status_bar_height_landscape">24.0dip</dimen>
-    <dimen name="quick_qs_offset_height">24.0dip</dimen>
+    <dimen name="status_bar_height_default">65.0px</dimen>
+    <dimen name="status_bar_height">65.0px</dimen>
+    <dimen name="status_bar_height_portrait">65.0px</dimen>
+    <dimen name="status_bar_height_landscape">65.0px</dimen>
+    <dimen name="rounded_corner_radius_top">58.0px</dimen>
+    <dimen name="rounded_corner_radius_bottom">58.0px</dimen>
 </resources>


### PR DESCRIPTION
Changelog:
* Update padding so that it can work on A12
* Add few array integer from stock
* Remove some useless stuff

Overlay tested and working fine on vivo Y20/Y12s
Thanks.