### PR TITLE
Add overlay for Redmi Note 11 4G (selene)

### DIFF
--- a/Xiaomi/RedmiNote114G-SystemUI/Android.mk
+++ b/Xiaomi/RedmiNote114G-SystemUI/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-redminote114g-systemui
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/RedmiNote114G-SystemUI/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote114G-SystemUI/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.redminote114g.systemui"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="com.android.systemui"
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="+(selene|selenes)"
+		android:priority="403"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/RedmiNote114G-SystemUI/res/values-land/config.xml
+++ b/Xiaomi/RedmiNote114G-SystemUI/res/values-land/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_header_height_keyguard">40dp</dimen>
+</resources>

--- a/Xiaomi/RedmiNote114G-SystemUI/res/values/config.xml
+++ b/Xiaomi/RedmiNote114G-SystemUI/res/values/config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="keyguard_carrier_text_margin">16dp</dimen>
+    <dimen name="notch_height">103px</dimen>
+    <dimen name="notch_width">66px</dimen>
+    <dimen name="rounded_corner_content_padding">50px</dimen>
+    <dimen name="status_bar_header_height_keyguard">40dp</dimen>
+    <dimen name="status_bar_padding_end">3px</dimen>
+    <dimen name="status_bar_padding_start">3px</dimen>
+</resources>

--- a/Xiaomi/RedmiNote114G/Android.mk
+++ b/Xiaomi/RedmiNote114G/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-redminote114g
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/RedmiNote114G/AndroidManifest.xml
+++ b/Xiaomi/RedmiNote114G/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.redminote114g"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.product.vendor.device"
+                android:requiredSystemPropertyValue="+(selene|selenes)"
+        android:priority="402"
+        android:isStatic="true" />
+</manifest>

--- a/Xiaomi/RedmiNote114G/res/values/config.xml
+++ b/Xiaomi/RedmiNote114G/res/values/config.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- arrays.xml files-->
+    <array name="config_ambientBrighteningThresholds">
+        <item>5</item>
+        <item>5</item>
+        <item>10</item>
+        <item>30</item>
+        <item>100</item>
+        <item>400</item>
+        <item>600</item>
+        <item>1000</item>
+    </array>
+    <array name="config_ambientDarkeningThresholds">
+        <item>800</item>
+        <item>800</item>
+        <item>800</item>
+        <item>800</item>
+        <item>800</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+    </array>
+    <array name="config_ambientThresholdLevels">
+        <item>2</item>
+        <item>10</item>
+        <item>30</item>
+        <item>100</item>
+        <item>800</item>
+        <item>2000</item>
+        <item>4000</item>
+    </array>
+    <array name="config_autoBrightnessLcdBacklightValues">
+        <item>3</item>
+        <item>3</item>
+        <item>3</item>
+        <item>3</item>
+        <item>8</item>
+        <item>13</item>
+        <item>20</item>
+        <item>25</item>
+        <item>33</item>
+        <item>41</item>
+        <item>45</item>
+        <item>45</item>
+        <item>45</item>
+        <item>47</item>
+        <item>50</item>
+        <item>58</item>
+        <item>63</item>
+        <item>67</item>
+        <item>72</item>
+        <item>90</item>
+        <item>99</item>
+        <item>150</item>
+        <item>175</item>
+        <item>208</item>
+        <item>248</item>
+        <item>255</item>
+    </array>
+    <array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>4</item>
+        <item>5</item>
+        <item>8</item>
+        <item>13</item>
+        <item>17</item>
+        <item>21</item>
+        <item>26</item>
+        <item>30</item>
+        <item>34</item>
+        <item>39</item>
+        <item>60</item>
+        <item>140</item>
+        <item>310</item>
+        <item>400</item>
+        <item>500</item>
+        <item>600</item>
+        <item>1000</item>
+        <item>1200</item>
+        <item>1500</item>
+        <item>2100</item>
+        <item>3000</item>
+        <item>3500</item>
+        <item>4000</item>
+    </array>
+    <array name="config_screenBrightnessNits">
+        <item>0</item>
+        <item>4</item>
+        <item>22</item>
+        <item>30</item>
+        <item>68</item>
+        <item>95</item>
+        <item>133</item>
+        <item>165</item>
+        <item>192</item>
+        <item>218</item>
+        <item>255</item>
+        <item>290</item>
+        <item>326</item>
+        <item>352</item>
+        <item>384</item>
+        <item>399</item>
+        <item>422</item>
+        <item>432</item>
+        <item>442</item>
+        <item>455</item>
+    </array>
+    <array name="config_screenBrighteningThresholds">
+        <item>0</item>
+    </array>
+    <array name="config_screenDarkeningThresholds">
+        <item>0</item>
+    </array>
+
+    <integer-array name="config_autoBrightnessDisplayValuesNits">
+        <item>5</item>
+        <item>5</item>
+        <item>5</item>
+        <item>5</item>
+        <item>15</item>
+        <item>24</item>
+        <item>37</item>
+        <item>47</item>
+        <item>61</item>
+        <item>76</item>
+        <item>83</item>
+        <item>83</item>
+        <item>83</item>
+        <item>87</item>
+        <item>93</item>
+        <item>107</item>
+        <item>117</item>
+        <item>124</item>
+        <item>133</item>
+        <item>166</item>
+        <item>182</item>
+        <item>270</item>
+        <item>315</item>
+        <item>373</item>
+        <item>442</item>
+        <item>455</item>
+    </integer-array>
+    <integer-array name="config_defaultNotificationVibePattern">
+        <item>0</item>
+        <item>350</item>
+        <item>250</item>
+        <item>350</item>
+    </integer-array>
+    <integer-array name="config_keyboardTapVibePattern">
+        <item>40</item>
+    </integer-array>
+    <integer-array name="config_longPressVibePattern">
+        <item>0</item>
+        <item>1</item>
+        <item>50</item>
+        <item>51</item>
+    </integer-array>
+    <integer-array name="config_notificationFallbackVibePattern">
+        <item>0</item>
+        <item>100</item>
+        <item>150</item>
+        <item>100</item>
+    </integer-array>
+    <integer-array name="config_safeModeEnabledVibePattern">
+        <item>0</item>
+        <item>1</item>
+        <item>20</item>
+        <item>21</item>
+        <item>500</item>
+        <item>600</item>
+    </integer-array>
+    <integer-array name="config_scrollBarrierVibePattern">
+        <item>0</item>
+        <item>15</item>
+        <item>10</item>
+        <item>10</item>
+    </integer-array>
+    <integer-array name="config_virtualKeyVibePattern">
+        <item>0</item>
+        <item>20</item>
+        <item>30</item>
+        <item>35</item>
+    </integer-array>
+    <integer-array name="config_tether_upstream_types">
+        <item>1</item>
+        <item>0</item>
+        <item>5</item>
+        <item>7</item>
+    </integer-array>
+    
+    <string-array name="config_biometric_sensors">
+        <item>0:2:15</item>
+    </string-array>
+    <string-array name="config_defaultPinnerServiceFiles">
+        <item>/data/dalvik-cache/arm64/system@framework@boot.oat</item>
+        <item>/data/dalvik-cache/arm/system@framework@boot.oat</item>
+        <item>/data/dalvik-cache/arm64/system@framework@services.jar@classes.dex</item>
+        <item>/data/dalvik-cache/arm/system@framework@services.jar@classes.dex</item>
+        <item>/system/framework/arm64/boot.oat</item>
+        <item>/system/framework/arm/boot.oat</item>
+        <item>/system/framework/oat/arm64/services.odex</item>
+        <item>/system/framework/oat/arm/services.odex</item>
+        <item>/system/framework/arm64/boot-framework.oat</item>
+        <item>/system/framework/arm/boot-framework.oat</item>
+        <item>/system/framework/arm64/boot-core-libart.oat</item>
+        <item>/system/framework/arm/boot-core-libart.oat</item>
+        <item>/system/lib64/libRScpp.so</item>
+        <item>/system/lib64/libRS.so</item>
+        <item>/system/lib64/libRS_internal.so</item>
+        <item>/system/lib64/libbcinfo.so</item>
+        <item>/system/lib64/libRSDriver.so</item>
+        <item>/system/lib64/libRSCpuRef.so</item>
+        <item>/system/lib64/libblas.so</item>
+    </string-array>
+    <string-array name="config_tether_usb_regexs">
+        <item>rndis\\d</item>
+    </string-array>
+    <string-array name="config_tether_wifi_regexs">
+        <item>ap\\d</item>
+    </string-array>
+    <string-array name="networkAttributes">
+        <item>wifi,1,1,1,-1,true</item>
+        <item>mobile,0,0,0,-1,true</item>
+        <item>mobile_mms,2,0,2,300000,true</item>
+        <item>mobile_supl,3,0,2,60000,true</item>
+        <item>mobile_dun,4,0,2,60000,true</item>
+        <item>mobile_hipri,5,0,3,60000,true</item>
+        <item>mobile_fota,10,0,2,60000,true</item>
+        <item>mobile_ims,11,0,-1,-1,true</item>
+        <item>mobile_cbs,12,0,2,60000,true</item>
+        <item>bluetooth,7,7,2,-1,true</item>
+        <item>ethernet,9,9,4,-1,true</item>
+        <item>wifi_p2p,13,1,0,-1,true</item>
+        <item>mobile_ia,14,0,2,-1,true</item>
+        <item>mobile_emergency,15,0,2,-1,true</item>
+        <item>mobile_dm,20,0,3,60000,true</item>
+        <item>mobile_wap,21,0,3,60000,true</item>
+        <item>mobile_net,22,0,3,60000,true</item>
+        <item>mobile_cmmail,23,0,3,60000,true</item>
+        <item>mobile_rcse,24,0,3,60000,true</item>
+        <item>mobile_xcap,25,0,3,60000,true</item>
+        <item>mobile_rcs,26,0,3,60000,true</item>
+        <item>mobile_bip,27,0,3,60000,true</item>
+        <item>mobile_vsim,28,0,-1,60000,true</item>
+        <item>mobile_preempt,29,0,9,60000,true</item>
+        <item>wifi_slave,40,1,0,-1,true</item>
+    </string-array>
+    <string-array name="radioAttributes">
+        <item>1,1</item>
+        <item>0,1</item>
+        <item>7,1</item>
+        <item>9,1</item>
+    </string-array>
+    
+    <!-- bools.xml files-->
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_carrier_volte_available">false</bool>
+    <bool name="config_carrier_wfc_ims_available">false</bool>
+    <bool name="config_device_volte_available">true</bool>
+    <bool name="config_device_vt_available">true</bool>
+    <bool name="config_device_wfc_ims_available">true</bool>
+    <bool name="config_dozeAfterScreenOffByDefault">true</bool>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">false</bool>
+    <bool name="config_dynamic_bind_ims">true</bool>
+    <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
+    <bool name="config_hotswapCapable">true</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">false</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_suspendWhenScreenOffDueToProximity">true</bool>
+    
+    <!-- dimens.xml files-->
+    <dimen name="rounded_corner_radius">20dp</dimen>
+    <dimen name="rounded_corner_radius_bottom">102px</dimen>
+    <dimen name="rounded_corner_radius_top">102px</dimen>
+    <dimen name="status_bar_height">93px</dimen>
+    <dimen name="status_bar_height_default">93px</dimen>
+    <dimen name="status_bar_height_landscape">93px</dimen>
+    <dimen name="status_bar_height_portrait">93px</dimen>
+    
+    <!-- fractions.xml files-->
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">100.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <fraction name="config_screenAutoBrightnessDozeScaleFactor">100.0%</fraction>
+    
+    <!-- integers.xml files-->
+    <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
+    <integer name="config_brightness_ramp_rate_fast">2466</integer>
+    <integer name="config_brightness_ramp_rate_slow">1973</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">20</integer>
+    <integer name="config_screenBrightnessDoze">1</integer>
+    <integer name="config_screenBrightnessForVrSettingDefault">688</integer>
+    <integer name="config_screenBrightnessForVrSettingMaximum">2047</integer>
+    <integer name="config_screenBrightnessForVrSettingMinimum">632</integer>
+    <integer name="config_screenBrightnessSettingDefault">1024</integer>
+    <integer name="config_screenBrightnessSettingMaximum">2047</integer>
+    <integer name="config_screenBrightnessSettingMinimum">5</integer>
+    <integer name="config_shutdownBatteryTemperature">600</integer>
+    
+    <!-- strings.xml files-->
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 H -35 V 103 H 35 V 0 H 0 Z</string>
+    <string name="wifi_tether_configure_ssid_default" translatable="false">Redmi Note 11 4G</string>
+</resources>

--- a/Xiaomi/RedmiNote114G/res/xml/power_profile.xml
+++ b/Xiaomi/RedmiNote114G/res/xml/power_profile.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="ambient.on">0.1</item>
+    <item name="screen.on">95.5</item>
+    <item name="screen.full">321.02</item>
+    <item name="bluetooth.active">63.81</item>
+    <item name="bluetooth.on">1.31</item>
+    <item name="wifi.on">0.3</item>
+    <item name="wifi.active">169.37</item>
+    <item name="wifi.scan">28</item>
+    <item name="audio">44.8</item>
+    <item name="video">32.5</item>
+    <item name="camera.flashlight">134.6</item>
+    <item name="camera.avg">339.13</item>
+    <item name="gps.on">0.25</item>
+    <item name="radio.active">210</item>
+    <item name="radio.scanning">0.1</item>
+    <array name="radio.on">
+        <value>9.5</value>
+        <value>9.5</value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>6</value>
+        <value>2</value>
+    </array>
+    <array name="cpu.speeds.cluster0">
+        <value>400000</value>
+    </array>
+    <array name="cpu.active.cluster0">
+        <value>13</value>
+        <value>17</value>
+        <value>19</value>
+        <value>20</value>
+        <value>22</value>
+        <value>24</value>
+        <value>26</value>
+        <value>28</value>
+        <value>31</value>
+        <value>35</value>
+        <value>38</value>
+        <value>40</value>
+        <value>44</value>
+        <value>47</value>
+        <value>55</value>
+        <value>59</value>
+    </array>
+    <array name="cpu.active.cluster1">
+        <value>48</value>
+        <value>52</value>
+        <value>61</value>
+        <value>72</value>
+        <value>84</value>
+        <value>100</value>
+        <value>109</value>
+        <value>125</value>
+        <value>139</value>
+        <value>157</value>
+        <value>175</value>
+        <value>196</value>
+        <value>209</value>
+        <value>219</value>
+        <value>233</value>
+        <value>245</value>
+    </array>
+    <item name="cpu.idle">4.08</item>
+    <item name="cpu.suspend">5</item>
+    <item name="cpu.active">2.55</item>. <item name="cpu.cluster_power.cluster0">2.11</item>
+    <item name="cpu.cluster_power.cluster1">2.22</item>
+    <array name="cpu.core_speeds.cluster0">
+        <value>1800000</value>
+        <value>1625000</value>
+        <value>1500000</value>
+        <value>1450000</value>
+        <value>1375000</value>
+        <value>1325000</value>
+        <value>1275000</value>
+        <value>1175000</value>
+        <value>1100000</value>
+        <value>1050000</value>
+        <value>999000</value>
+        <value>950000</value>
+        <value>900000</value>
+        <value>850000</value>
+        <value>774000</value>
+        <value>500000</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>2000000</value>
+        <value>1950000</value>
+        <value>1900000</value>
+        <value>1850000</value>
+        <value>1800000</value>
+        <value>1710000</value>
+        <value>1621000</value>
+        <value>1532000</value>
+        <value>1443000</value>
+        <value>1354000</value>
+        <value>1295000</value>
+        <value>1176000</value>
+        <value>1087000</value>
+        <value>998000</value>
+        <value>909000</value>
+        <value>850000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>13</value>
+        <value>17</value>
+        <value>19</value>
+        <value>20</value>
+        <value>22</value>
+        <value>24</value>
+        <value>26</value>
+        <value>28</value>
+        <value>31</value>
+        <value>35</value>
+        <value>38</value>
+        <value>40</value>
+        <value>44</value>
+        <value>47</value>
+        <value>55</value>
+        <value>59</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>48</value>
+        <value>52</value>
+        <value>61</value>
+        <value>72</value>
+        <value>84</value>
+        <value>100</value>
+        <value>109</value>
+        <value>125</value>
+        <value>139</value>
+        <value>157</value>
+        <value>175</value>
+        <value>196</value>
+        <value>209</value>
+        <value>219</value>
+        <value>233</value>
+        <value>245</value>
+    </array>
+    <array name="memory.bandwidths">
+        <value>22.7</value>
+    </array>
+    <item name="battery.capacity">5000</item>
+    <item name="wifi.controller.idle">0</item>
+    <item name="wifi.controller.rx">0</item>
+    <item name="wifi.controller.tx">0</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">0</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+    <item name="modem.controller.sleep">0</item>
+    <item name="modem.controller.idle">0</item>
+    <item name="modem.controller.rx">0</item>
+    <array name="modem.controller.tx">
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+        <value>0</value>
+    </array>
+    <item name="modem.controller.voltage">0</item>
+    <array name="gps.signalqualitybased">
+        <value>0</value>
+        <value>0</value>
+    </array>
+    <item name="gps.voltage">0</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -314,6 +314,8 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redminote10pro \
 	treble-overlay-xiaomi-redminote10s \
 	treble-overlay-xiaomi-redminote11 \
+	treble-overlay-xiaomi-redminote114g \
+	treble-overlay-xiaomi-redminote114g-systemui \
 	treble-overlay-xiaomi-redminote5 \
 	treble-overlay-xiaomi-redminote6pro \
 	treble-overlay-xiaomi-redminote6pro-systemui \


### PR DESCRIPTION
The overlay for Redmi Note 11 4G(China) / Redmi 10 2021 / Redmi 10 2022
Code : **selene**,**selenes**
Config form V12.5.12.0.RKUCNXM,Android R