### PR TITLE
FP3 does not support swiping on fingerprint sensor

### DIFF
--- a/Fairphone/FP3/res/values/config.xml
+++ b/Fairphone/FP3/res/values/config.xml
@@ -44,7 +44,7 @@
     <bool name="config_showNavigationBar">true</bool>
 
     <!-- Enable system navigation keys. -->
-    <bool name="config_supportSystemNavigationKeys">true</bool>
+    <bool name="config_supportSystemNavigationKeys">false</bool>
 
     <!-- When true use the linux /dev/input/event subsystem to detect the switch changes
          on the headphone/microphone jack. When false use the older uevent framework. -->


### PR DESCRIPTION
Despite the name `config_supportSystemNavigationKeys`, it controls the swipe on fingerprint sensor gesture.