### PR TITLE
Samsung Galaxy A20: Fix fingerprint detection on some A20 devices

### DIFF
--- a/Samsung/A20/AndroidManifest.xml
+++ b/Samsung/A20/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:versionName="1.0">
         <overlay android:targetPackage="android"
         	android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
-        	android:requiredSystemPropertyValue="+(*samsung/a20dd/a20*|samsung/a20/a20*)"
+        	android:requiredSystemPropertyValue="+samsung/a20*/a20:*"
 		android:priority="660"
 		android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Current overlay tries to find the fingerprint with `+(*samsung/a20dd/a20*|samsung/a20/a20*)`, in order to prevent the overlay from being loaded in other devices (A20s, A20e). However, the A20 has more fingerprint variants like a20ub and a20cs. This solution makes sure to detect them while still ignoring fingerprints from other devices.