### PR TITLE
Add overlay for Moto G Pure (2021)

### DIFF
--- a/Moto/GPure/Android.mk
+++ b/Moto/GPure/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-moto-gpure
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Moto/GPure/AndroidManifest.xml
+++ b/Moto/GPure/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.moto.gpure"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+motorola/ellis*"
+		android:priority="236"
+		android:isStatic="true" />
+</manifest>

--- a/Moto/GPure/res/values/arrays.xml
+++ b/Moto/GPure/res/values/arrays.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="config_autoBrightnessDisplayValuesNits">
+        <item>3</item>
+        <item>10</item>
+        <item>20</item>
+        <item>50</item>
+        <item>70</item>
+        <item>85</item>
+        <item>110</item>
+        <item>130</item>
+        <item>150</item>
+        <item>160</item>
+        <item>160</item>
+        <item>180</item>
+        <item>180</item>
+        <item>225</item>
+        <item>225</item>
+        <item>225</item>
+        <item>230</item>
+        <item>245</item>
+        <item>300</item>
+        <item>380</item>
+        <item>400</item>
+        <item>400</item>
+        <item>400</item>
+        <item>400</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>5</item>
+        <item>10</item>
+        <item>29</item>
+        <item>50</item>
+        <item>90</item>
+        <item>100</item>
+        <item>150</item>
+        <item>200</item>
+        <item>300</item>
+        <item>400</item>
+        <item>500</item>
+        <item>800</item>
+        <item>1000</item>
+        <item>1300</item>
+        <item>1500</item>
+        <item>1600</item>
+        <item>1800</item>
+        <item>2000</item>
+        <item>3000</item>
+        <item>4000</item>
+        <item>8000</item>
+    </integer-array>
+    <integer-array name="config_availableColorModes">
+        <item>0</item>
+        <item>2</item>
+    </integer-array>
+    <string-array name="config_biometric_sensors">
+        <item>0:2:15</item>
+    </string-array>
+    <integer-array name="config_screenBrightnessBacklight">
+        <item>0</item>
+        <item>2</item>
+        <item>6</item>
+        <item>13</item>
+        <item>32</item>
+        <item>45</item>
+        <item>54</item>
+        <item>70</item>
+        <item>83</item>
+        <item>96</item>
+        <item>102</item>
+        <item>115</item>
+        <item>143</item>
+        <item>147</item>
+        <item>156</item>
+        <item>191</item>
+        <item>242</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_screenBrightnessNits">
+        <item>0</item>
+        <item>3</item>
+        <item>10</item>
+        <item>20</item>
+        <item>50</item>
+        <item>70</item>
+        <item>85</item>
+        <item>110</item>
+        <item>130</item>
+        <item>150</item>
+        <item>160</item>
+        <item>180</item>
+        <item>225</item>
+        <item>230</item>
+        <item>245</item>
+        <item>300</item>
+        <item>380</item>
+        <item>400</item>
+    </integer-array>
+</resources>

--- a/Moto/GPure/res/values/bools.xml
+++ b/Moto/GPure/res/values/bools.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_supportSystemNavigationKeys">true</bool>
+</resources>

--- a/Moto/GPure/res/values/integers.xml
+++ b/Moto/GPure/res/values/integers.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="config_autoBrightnessBrighteningLightDebounce">500</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">500</integer>
+    <integer name="config_cameraLaunchGestureSensorType">-1</integer>
+    <integer name="config_screenBrightnessDark">3</integer>
+    <integer name="config_screenBrightnessDim">3</integer>
+    <integer name="config_screenBrightnessSettingDefault">121</integer>
+    <integer name="config_screenBrightnessSettingMinimum">3</integer>
+</resources>

--- a/Moto/GPure/res/values/strings.xml
+++ b/Moto/GPure/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="config_cameraLaunchGestureSensorStringType" />
+    <string name="config_mainBuiltInDisplayCutout">M 40,0 L -40,0 L -40,54 L 40,54 Z</string>
+</resources>

--- a/Moto/GPure/res/xml/power_profile.xml
+++ b/Moto/GPure/res/xml/power_profile.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">68.384</item>
+    <item name="screen.full">274.67</item>
+    <item name="wifi.on">0.572</item>
+    <item name="wifi.active">55.58</item>
+    <item name="wifi.scan">78</item>
+    <item name="camera.avg">637.343</item>
+    <item name="camera.flashlight">165.8</item>
+    <item name="gps.on">27.16</item>
+    <item name="radio.active">147.291</item>
+    <item name="radio.scanning">40.7</item>
+    <array name="radio.on">
+        <value>35</value>
+        <value>30</value>
+        <value>25</value>
+        <value>20</value>
+        <value>15</value>
+        <value>10</value>
+        <value>5</value>
+        <value>2.487</value>
+    </array>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>4</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>900000</value>
+        <value>979000</value>
+        <value>1085000</value>
+        <value>1218000</value>
+        <value>1351000</value>
+        <value>1484000</value>
+        <value>1617000</value>
+        <value>1750000</value>
+        <value>1779000</value>
+        <value>1809000</value>
+        <value>1838000</value>
+        <value>1868000</value>
+        <value>1897000</value>
+        <value>1927000</value>
+        <value>1961000</value>
+        <value>2001000</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>400000</value>
+        <value>501000</value>
+        <value>542000</value>
+        <value>643000</value>
+        <value>745000</value>
+        <value>846000</value>
+        <value>948000</value>
+        <value>1050000</value>
+        <value>1102000</value>
+        <value>1155000</value>
+        <value>1208000</value>
+        <value>1261000</value>
+        <value>1314000</value>
+        <value>1367000</value>
+        <value>1429000</value>
+        <value>1500000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>35.66</value>
+        <value>37.5</value>
+        <value>39.36</value>
+        <value>43.735</value>
+        <value>47.3</value>
+        <value>51.68</value>
+        <value>58.87</value>
+        <value>64.138</value>
+        <value>71.471</value>
+        <value>77.211</value>
+        <value>82.255</value>
+        <value>88.026</value>
+        <value>90.215</value>
+        <value>92.713</value>
+        <value>93.156</value>
+        <value>96.54</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>25.648</value>
+        <value>27.122</value>
+        <value>28.124</value>
+        <value>29.69</value>
+        <value>31.957</value>
+        <value>34.928</value>
+        <value>37.841</value>
+        <value>41.099</value>
+        <value>43.547</value>
+        <value>45.774</value>
+        <value>47.834</value>
+        <value>50.871</value>
+        <value>53.286</value>
+        <value>55.263</value>
+        <value>59.968</value>
+        <value>64.28</value>
+    </array>
+    <item name="cpu.cluster_power.cluster0">12.979</item>
+    <item name="cpu.cluster_power.cluster1">7.704</item>
+    <item name="cpu.suspend">3</item>
+    <item name="cpu.idle">4.776</item>
+    <item name="cpu.active">6.37</item>
+    <item name="battery.capacity">4000</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -89,6 +89,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-moto-g8 \
 	treble-overlay-moto-g8plus \
 	treble-overlay-moto-g8power \
+	treble-overlay-moto-gpure \
 	treble-overlay-moto-hiphi \
 	treble-overlay-moto-hiphi-systemui \
 	treble-overlay-moto-nio \


### PR DESCRIPTION
This should hopefully be an overlay for the Motorola G Pure 2021 (ellis).  It's based on the latest stock vendor file.