### PR TITLE
Add more status bar height overrides for Umidigi A13 Pro Max

### DIFF
--- a/Umidigi/A13_Pro_Max_5G/res/values/dimens.xml
+++ b/Umidigi/A13_Pro_Max_5G/res/values/dimens.xml
@@ -2,6 +2,8 @@
 <resources>
     <item type="dimen" name="config_screenBrightnessSettingMaximumFloat">1.0</item>
     <item type="dimen" name="config_screenBrightnessSettingMinimumFloat">0.0</item>
+    <dimen name="status_bar_height">130.0px</dimen>
+    <dimen name="status_bar_height_default">130.0px</dimen>
     <dimen name="status_bar_height_portrait">130.0px</dimen>
-    <dimen name="status_bar_height_landscape">130.0px</dimen>
+    <dimen name="status_bar_height_landscape">24.0dip</dimen>
 </resources>


### PR DESCRIPTION
The original PR submitted worked for a bit then stopped working after a few reboot cycles, not entirely clear on why.  In any case, adding these additional values has fixed it again across many test reboots.