### PR TITLE
Add Xiaomi 11T overlays

### DIFF
--- a/Xiaomi/Mi11T/Android.mk
+++ b/Xiaomi/Mi11T/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-xiaomi-mi11t
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Xiaomi/Mi11T/AndroidManifest.xml
+++ b/Xiaomi/Mi11T/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.xiaomi.mi11t"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*iaomi/amber*"
+		android:priority="69"
+		android:isStatic="true" />
+</manifest>

--- a/Xiaomi/Mi11T/res/values/bluetooth.xml
+++ b/Xiaomi/Mi11T/res/values/bluetooth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_bluetooth_hfp_inband_ringing_support">false</bool>
+</resources>

--- a/Xiaomi/Mi11T/res/values/display.xml
+++ b/Xiaomi/Mi11T/res/values/display.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_automatic_brightness_available">true</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    
+    <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
+    <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+    <fraction name="config_screenAutoBrightnessDozeScaleFactor">100.0%</fraction>
+    
+    <integer name="config_autoBrightnessBrighteningLightDebounce">1000</integer>
+    <integer name="config_autoBrightnessDarkeningLightDebounce">1000</integer>
+    <integer name="config_brightness_ramp_rate_fast">180</integer>
+    <integer name="config_brightness_ramp_rate_slow">60</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
+    <integer name="config_screenBrightnessDim">10</integer>
+    <integer name="config_screenBrightnessDoze">17</integer>
+        <integer name="config_screenBrightnessForVrSettingDefault">86</integer>
+    <integer name="config_screenBrightnessForVrSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessForVrSettingMinimum">79</integer>
+    <integer name="config_screenBrightnessSettingDefault">67</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessSettingMinimum">1</integer> 
+    <integer name="config_defaultPeakRefreshRate">120</integer>   
+    
+    <integer-array name="config_ambientBrighteningThresholds">
+        <item>2</item>
+        <item>6</item>
+        <item>10</item>
+        <item>30</item>
+        <item>100</item>
+        <item>400</item>
+        <item>600</item>
+        <item>1000</item>
+    </integer-array>
+        <integer-array name="config_ambientDarkeningThresholds">
+        <item>800</item>
+        <item>800</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+    </integer-array>
+    <integer-array name="config_ambientThresholdLevels">
+        <item>2</item>
+        <item>10</item>
+        <item>30</item>
+        <item>100</item>
+        <item>800</item>
+        <item>2000</item>
+        <item>4000</item>
+    </integer-array>
+    <array name="config_autoBrightnessDisplayValuesNits">
+        <item>3.5</item>
+        <item>4.3</item>
+        <item>5.0</item>
+        <item>17.0</item>
+        <item>24.3</item>
+        <item>29.7</item>
+        <item>34.0</item>
+        <item>46.0</item>
+        <item>59.0</item>
+        <item>76.0</item>
+        <item>81.0</item>
+        <item>82.0</item>
+        <item>82.0</item>
+        <item>82.0</item>
+        <item>83.0</item>
+        <item>83.0</item>
+        <item>83.0</item>
+        <item>84.0</item>
+        <item>84.0</item>
+        <item>85.0</item>
+        <item>85.0</item>
+        <item>85.0</item>
+        <item>85.0</item>
+        <item>86.0</item>
+        <item>86.0</item>
+        <item>87.0</item>
+        <item>89.0</item>
+        <item>90.0</item>
+        <item>91.0</item>
+        <item>93.0</item>
+        <item>94.0</item>
+        <item>96.0</item>
+        <item>97.0</item>
+        <item>99.0</item>
+        <item>100.0</item>
+        <item>101.0</item>
+        <item>104.0</item>
+        <item>105.0</item>
+        <item>106.0</item>
+        <item>108.0</item>
+        <item>109.0</item>
+        <item>111.0</item>
+        <item>112.0</item>
+        <item>114.0</item>
+        <item>116.0</item>
+        <item>137.0</item>
+        <item>157.0</item>
+        <item>180.0</item>
+        <item>205.0</item>
+        <item>226.0</item>
+        <item>257.0</item>
+        <item>280.0</item>
+        <item>295.0</item>
+        <item>369.0</item>
+        <item>400.0</item>
+        <item>416.7</item>
+        <item>433.3</item>
+        <item>450.0</item>
+        <item>466.7</item>
+        <item>483.3</item>
+        <item>500.0</item>
+        <item>512.5</item>
+        <item>525.0</item>
+        <item>537.5</item>
+        <item>550.0</item>
+        <item>562.5</item>
+        <item>575.0</item>
+        <item>587.5</item>
+        <item>600.0</item>
+        <item>610.0</item>
+        <item>620.0</item>
+        <item>630.0</item>
+        <item>640.0</item>
+        <item>650.0</item>
+        <item>660.0</item>
+        <item>670.0</item>
+        <item>680.0</item>
+        <item>690.0</item>
+        <item>700.0</item>
+        <item>705.0</item>
+        <item>710.0</item>
+        <item>715.0</item>
+        <item>720.0</item>
+        <item>725.0</item>
+        <item>730.0</item>
+        <item>735.0</item>
+        <item>740.0</item>
+        <item>745.0</item>
+        <item>750.0</item>
+        <item>755.0</item>
+        <item>760.0</item>
+        <item>765.0</item>
+        <item>770.0</item>
+        <item>775.0</item>
+        <item>800.0</item>
+        <item>816.7</item>
+        <item>833.3</item>
+        <item>850.0</item>
+        <item>866.7</item>
+        <item>883.3</item>
+        <item>900.0</item>
+        <item>914.3</item>
+        <item>928.6</item>
+        <item>942.9</item>
+        <item>957.1</item>
+        <item>971.4</item>
+        <item>985.7</item>
+        <item>1000.0</item>
+    </array>
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>4</item>
+        <item>4</item>
+        <item>4</item>
+        <item>8</item>
+        <item>15</item>
+        <item>20</item>
+        <item>26</item>
+        <item>35</item>
+        <item>45</item>
+        <item>46</item>
+        <item>46</item>
+        <item>46</item>
+        <item>60</item>
+        <item>60</item>
+        <item>60</item>
+        <item>64</item>
+        <item>66</item>
+        <item>70</item>
+        <item>73</item>
+        <item>80</item>
+        <item>88</item>
+        <item>110</item>
+        <item>130</item>
+        <item>135</item>
+        <item>145</item>
+        <item>180</item>
+        <item>200</item>
+        <item>240</item>
+        <item>255</item>
+    </integer-array>
+    <integer-array name="config_autoBrightnessLevels">
+        <item>1</item>
+        <item>2</item>
+        <item>5</item>
+        <item>9</item>
+        <item>13</item>
+        <item>17</item>
+        <item>21</item>
+        <item>26</item>
+        <item>30</item>
+        <item>40</item>
+        <item>83</item>
+        <item>104</item>
+        <item>200</item>
+        <item>400</item>
+        <item>500</item>
+        <item>600</item>
+        <item>700</item>
+        <item>800</item>
+        <item>1000</item>
+        <item>1200</item>
+        <item>1500</item>
+        <item>1800</item>
+        <item>2000</item>
+        <item>2165</item>
+        <item>2680</item>
+        <item>3000</item>
+        <item>3540</item>
+        <item>4000</item>
+    </integer-array>
+
+    <integer-array name="config_dynamicHysteresisBrightLevels">
+        <item>2000</item>
+        <item>2000</item>
+        <item>1000</item>
+        <item>1000</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+    </integer-array>
+    <integer-array name="config_dynamicHysteresisDarkLevels">
+        <item>800</item>
+        <item>800</item>
+        <item>800</item>
+        <item>800</item>
+        <item>800</item>
+        <item>500</item>
+        <item>500</item>
+        <item>500</item>
+    </integer-array>
+    <integer-array name="config_dynamicHysteresisLuxLevels">
+        <item>2</item>
+        <item>10</item>
+        <item>30</item>
+        <item>100</item>
+        <item>800</item>
+        <item>2000</item>
+        <item>4000</item>
+    </integer-array>
+    <integer-array name="config_screenBrighteningThresholds">
+        <item>0</item>
+    </integer-array>
+    <integer-array name="config_screenDarkeningThresholds">
+        <item>0</item>
+    </integer-array>
+
+</resources>

--- a/Xiaomi/Mi11T/res/values/doze.xml
+++ b/Xiaomi/Mi11T/res/values/doze.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains misc non default vars -->
+<resources>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+    <bool name="config_dozeSupportsAodWallpaper">false</bool>
+    <bool name="config_displayBlanksAfterDoze">false</bool>
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    <bool name="config_displayBrightnessBucketsInDoze">false</bool>
+</resources>
+

--- a/Xiaomi/Mi11T/res/values/location.xml
+++ b/Xiaomi/Mi11T/res/values/location.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Support non default location providers -->
+<resources>
+    <bool name="config_enableFusedLocationOverlay">false</bool>
+    <bool name="config_enableNetworkLocationOverlay">false</bool>
+</resources>

--- a/Xiaomi/Mi11T/res/values/misc.xml
+++ b/Xiaomi/Mi11T/res/values/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains misc non default vars -->
+<resources>
+    <integer name="config_shutdownBatteryTemperature">600</integer>
+</resources>

--- a/Xiaomi/Mi11T/res/values/network.xml
+++ b/Xiaomi/Mi11T/res/values/network.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains misc non default vars -->
+<resources>
+    <bool name="config_dynamic_bind_ims">true</bool>
+    <bool name="config_hotswapCapable">true</bool>    
+    <bool name="config_switch_phone_on_voice_reg_state_change">false</bool>
+    <bool name="config_wifi_background_scan_support">true</bool>
+    <bool name="config_wifi_dual_band_support">true</bool>
+    <bool name="skip_restoring_network_selection">true</bool>
+</resources>

--- a/Xiaomi/Mi11T/res/values/notch.xml
+++ b/Xiaomi/Mi11T/res/values/notch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <dimen name="rounded_corner_radius">20.0dip</dimen>
+    <item type="dimen" name="status_bar_height">24.0dip</item>
+    <item type="dimen" name="status_bar_height_landscape">24.0dip</item>
+    <dimen name="status_bar_height_portrait">48.0dip</dimen>
+    <string name="config_mainBuiltInDisplayCutout">M 0,0 H -27 V 84 H 27 V 0 H 0 Z</string>
+    <bool name="config_fillMainBuiltInDisplayCutout">false</bool>
+</resources>

--- a/Xiaomi/Mi11T/res/values/sensors.xml
+++ b/Xiaomi/Mi11T/res/values/sensors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains misc non default vars -->
+<resources>
+    <bool name="config_suspendWhenScreenOffDueToProximity">false</bool>
+    <bool name="config_lidControlsSleep">true</bool>
+</resources>

--- a/Xiaomi/Mi11T/res/xml/power_profile.xml
+++ b/Xiaomi/Mi11T/res/xml/power_profile.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">49.98</item>
+    <item name="screen.full">289.51</item>
+    <item name="bluetooth.active">25.02</item>
+    <item name="bluetooth.on">2.03</item>
+    <item name="wifi.on">1.47</item>
+    <item name="wifi.active">167.39</item>
+    <item name="wifi.scan">24.79</item>
+    <item name="dsp.audio">16.14</item>
+    <item name="dsp.video">73.53</item>
+    <item name="camera.flashlight">0.1</item>
+    <item name="camera.avg">633.84</item>
+    <item name="gps.on">33.49</item>
+    <item name="radio.active">261.81</item>
+    <item name="radio.scanning">0.1</item>
+    <array name="radio.on">
+        <value>7.68</value>
+        <value>7.68</value>
+    </array>
+    <item name="modem.controller.idle">0</item>
+    <item name="modem.controller.rx">0</item>
+    <item name="modem.controller.tx">0</item>
+    <item name="modem.controller.voltage">0</item>
+    <array name="cpu.clusters.cores">
+        <value>6</value>
+        <value>2</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>500000</value>
+        <value>774000</value>
+        <value>875000</value>
+        <value>975000</value>
+        <value>1075000</value>
+        <value>1175000</value>
+        <value>1275000</value>
+        <value>1375000</value>
+        <value>1500000</value>
+        <value>1618000</value>
+        <value>1666000</value>
+        <value>1733000</value>
+        <value>1800000</value>
+        <value>1866000</value>
+        <value>1933000</value>
+        <value>2000000</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>19.55</value>
+        <value>23.5</value>
+        <value>25</value>
+        <value>27.86</value>
+        <value>31.24</value>
+        <value>35.5</value>
+        <value>39.69</value>
+        <value>44.83</value>
+        <value>52.33</value>
+        <value>58.95</value>
+        <value>62.05</value>
+        <value>66.61</value>
+        <value>72.77</value>
+        <value>80.27</value>
+        <value>85.8</value>
+        <value>90.04</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>774000</value>
+        <value>835000</value>
+        <value>919000</value>
+        <value>1002000</value>
+        <value>1085000</value>
+        <value>1169000</value>
+        <value>1308000</value>
+        <value>1419000</value>
+        <value>1530000</value>
+        <value>1670000</value>
+        <value>1733000</value>
+        <value>1796000</value>
+        <value>1860000</value>
+        <value>1923000</value>
+        <value>1986000</value>
+        <value>2050000</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>56.85</value>
+        <value>61.38</value>
+        <value>70.65</value>
+        <value>79.53</value>
+        <value>91.11</value>
+        <value>105.19</value>
+        <value>130.33</value>
+        <value>152.46</value>
+        <value>177.39</value>
+        <value>209.73</value>
+        <value>233.56</value>
+        <value>247.53</value>
+        <value>269.61</value>
+        <value>291.52</value>
+        <value>307.98</value>
+        <value>324.33</value>
+    </array>
+    <item name="cpu.idle">6.18</item>
+    <array name="memory.bandwidths">
+        <value>22.7</value>
+    </array>
+    <item name="battery.capacity">4500</item>
+    <item name="wifi.controller.idle">0</item>
+    <item name="wifi.controller.rx">0</item>
+    <item name="wifi.controller.tx">0</item>
+    <array name="wifi.controller.tx_levels" />
+    <item name="wifi.controller.voltage">0</item>
+    <array name="wifi.batchedscan">
+        <value>.0002</value>
+        <value>.002</value>
+        <value>.02</value>
+        <value>.2</value>
+        <value>2</value>
+    </array>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -275,6 +275,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-civi \
 	treble-overlay-xiaomi-civi-systemui \
 	treble-overlay-xiaomi-mi11lite5g \
+	treble-overlay-xiaomi-mi11t \
 	treble-overlay-xiaomi-mi11tpro \
 	treble-overlay-xiaomi-mi6x \
 	treble-overlay-xiaomi-mi8 \


### PR DESCRIPTION
Fixed, I did take a lot of values from vili as I just remembered that the outer design and the display are exactly the same (except Dolby Vision) since my dump couldn't provide them for some reason.

I just imported some display-related values carefully, and also improved the device check by kanging from vili.