### PR TITLE
Add the Overlay for Huawei JKM

### DIFF
--- a/Huawei/kirin710/JKM/Android.mk
+++ b/Huawei/kirin710/JKM/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-huawei-JKM
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Huawei/kirin710/JKM/AndroidManifest.xml
+++ b/Huawei/kirin710/JKM/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.huawei.JKM"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.hw.oemName"
+                android:requiredSystemPropertyValue="+JKM*"
+		android:priority="916"
+		android:isStatic="true" />
+</manifest>

--- a/Huawei/kirin710/JKM/res/values-land/notch.xml
+++ b/Huawei/kirin710/JKM/res/values-land/notch.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="status_bar_height">5.439972mm</dimen>
+</resources>

--- a/Huawei/kirin710/JKM/res/values/config.xml
+++ b/Huawei/kirin710/JKM/res/values/config.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate.
+
+     NOTE: The naming convention is "config_camelCaseValue". Some legacy
+     entries do not follow the convention, but all new entries should. -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
+         The N entries of this array define N + 1 control points as follows:
+         (1-based arrays)
+
+         Point 1:            (0, value[1]):             lux <= 0
+         Point 2:     (level[1], value[2]):  0        < lux <= level[1]
+         Point 3:     (level[2], value[3]):  level[2] < lux <= level[3]
+         ...
+         Point N+1: (level[N], value[N+1]):  level[N] < lux
+
+         The control points must be strictly increasing.  Each control point
+         corresponds to an entry in the brightness backlight values arrays.
+         For example, if LUX == level[1] (first element of the levels array)
+         then the brightness will be determined by value[2] (second element
+         of the brightness values array).
+
+         Spline interpolation is used to determine the auto-brightness
+         backlight values for LUX levels between these control points.
+
+         Must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessLevels">
+        <item>8</item>
+        <item>55</item>
+        <item>350</item>
+        <item>1600</item>
+        <item>2550</item>
+    </integer-array>
+
+    <!-- Array of output values for LCD backlight corresponding to the LUX values
+         in the config_autoBrightnessLevels array.  This array should have size one greater
+         than the size of the config_autoBrightnessLevels array.
+         The brightness values must be between 0 and 255 and be non-decreasing.
+         This must be overridden in platform specific overlays -->
+    <integer-array name="config_autoBrightnessLcdBacklightValues">
+        <item>6</item>
+        <item>47</item>
+        <item>150</item>
+        <item>180</item>
+        <item>250</item>
+        <item>255</item>
+    </integer-array>
+	
+    <integer name="config_screenBrightnessDark">4</integer>
+    
+    <!-- Minimum screen brightness allowed by the power manager. -->
+    <integer name="config_screenBrightnessDim">6</integer>
+
+    <!-- Minimum screen brightness setting allowed by the power manager.
+         The user is forbidden from setting the brightness below this level. -->
+    <integer name="config_screenBrightnessSettingMinimum">4</integer>
+    
+    <integer name="config_screenBrightnessSettingDefault">33</integer>
+    <integer name="config_screenBrightnessSettingMaximum">255</integer>
+
+    <!-- Flag indicating whether the we should enable the automatic brightness in Settings.
+         Software implementation will be used if config_hardware_auto_brightness_available is not set -->
+    <bool name="config_automatic_brightness_available">true</bool>
+
+    <!-- Boolean indicating if current platform supports BLE peripheral mode -->
+    <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+
+    <!-- If true, the doze component is not started until after the screen has been
+         turned off and the screen off animation has been performed. -->
+    <bool name="config_dozeAfterScreenOff">false</bool>
+
+	<!-- Power Management: Specifies whether to decouple the auto-suspend state of the
+         device from the display on/off state.
+         When false, autosuspend_disable() will be called before the display is turned on
+         and autosuspend_enable() will be called after the display is turned off.
+         This mode provides best compatibility for devices using legacy power management
+         features such as early suspend / late resume.
+         When true, autosuspend_display() and autosuspend_enable() will be called
+         independently of whether the display is being turned on or off.  This mode
+         enables the power manager to suspend the application processor while the
+         display is on.
+         This resource should be set to "true" when a doze component has been specified
+         to maximize power savings but not all devices support it.
+         Refer to autosuspend.h for details.
+    -->
+    <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">false</bool>
+    
+	<!-- Indicate whether to allow the device to suspend when the screen is off
+         due to the proximity sensor.  This resource should only be set to true
+         if the sensor HAL correctly handles the proximity sensor as a wake-up source.
+         Otherwise, the device may fail to wake out of suspend reliably.
+         The default is false. -->
+    <bool name="config_suspendWhenScreenOffDueToProximity">false</bool>
+    
+	<!-- Power Management: Specifies whether to decouple the interactive state of the
+         device from the display on/off state.
+         When false, setInteractive(..., true) will be called before the display is turned on
+         and setInteractive(..., false) will be called after the display is turned off.
+         This mode provides best compatibility for devices that expect the interactive
+         state to be tied to the display state.
+         When true, setInteractive(...) will be called independently of whether the display
+         is being turned on or off.  This mode enables the power manager to reduce
+         clocks and disable the touch controller while the display is on.
+         This resource should be set to "true" when a doze component has been specified
+         to maximize power savings but not all devices support it.
+         Refer to power.h for details.
+    -->
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">false</bool>
+	
+
+    <!-- Screen brightness used to dim the screen while dozing in a very low power state.
+         May be less than the minimum allowed brightness setting
+         that can be set by the user. -->
+    <integer name="config_screenBrightnessDoze">4</integer>
+
+    <!-- Is the notification LED intrusive? Used to decide if there should be a disable option -->
+    <bool name="config_intrusiveNotificationLed">true</bool>
+
+    <!-- List of regexpressions describing the interface (if any) that represent tetherable
+         USB interfaces.  If the device doesn't want to support tething over USB this should
+         be empty.  An example would be "usb.*" -->
+    <string-array translatable="false" name="config_tether_usb_regexs">
+        <item>"rndis0"</item>
+    </string-array>
+
+    <!-- List of regexpressions describing the interface (if any) that represent tetherable
+         Wifi interfaces.  If the device doesn't want to support tethering over Wifi this
+         should be empty.  An example would be "softap.*" -->
+    <string-array  translatable="false" name="config_tether_wifi_regexs">
+        <item>wlan0|ap0</item>
+    </string-array>
+
+    <!-- List of regexpressions describing the interface (if any) that represent tetherable
+         bluetooth interfaces.  If the device doesn't want to support tethering over bluetooth this
+         should be empty. -->
+    <string-array translatable="false" name="config_tether_bluetooth_regexs">
+        <item>"bt-pan"</item>
+    </string-array>
+
+    <!-- Array of allowable ConnectivityManager network types for tethering -->
+    <!-- Common options are [1, 4] for TYPE_WIFI and TYPE_MOBILE_DUN or
+         [0,1,5,7] for TYPE_MOBILE, TYPE_WIFI, TYPE_MOBILE_HIPRI and TYPE_BLUETOOTH -->
+    <integer-array  translatable="false" name="config_tether_upstream_types">
+        <item>1</item>
+        <item>7</item>
+        <item>0</item>
+    </integer-array>
+
+    <!-- Is the device capable of hot swapping an UICC Card -->
+    <bool name="config_hotswapCapable">false</bool>
+
+    <!-- Boolean indicating whether the HWC setColorTransform function can be performed efficiently
+         in hardware. -->
+    <bool name="config_setColorTransformAccelerated">true</bool>
+
+    <!-- Flag specifying whether VoLTE is available on device -->
+    <bool name="config_device_volte_available">true</bool>
+
+    <!-- Flag specifying whether VoLTE should be available for carrier: independent of
+         carrier provisioning. If false: hard disabled. If true: then depends on carrier
+         provisioning, availability etc -->
+    <bool name="config_carrier_volte_available">true</bool>
+
+    <!-- Flag specifying whether WFC over IMS is available on device -->
+    <bool name="config_device_wfc_ims_available">true</bool>
+
+    <!-- Flag specifying whether WFC over IMS should be available for carrier: independent of
+         carrier provisioning. If false: hard disabled. If true: then depends on carrier
+         provisioning, availability etc -->
+    <bool name="config_carrier_wfc_ims_available">true</bool>
+
+
+    <!-- When true use the linux /dev/input/event subsystem to detect the switch changes
+         on the headphone/microphone jack. When false use the older uevent framework. -->
+    
+    <!-- Brightness -->
+    <integer name="config_screenBrightnessForVrSettingDefault">86</integer>
+    <integer name="config_screenBrightnessForVrSettingMaximum">255</integer>
+    <integer name="config_screenBrightnessForVrSettingMinimum">79</integer>
+
+    <!-- Wifi -->
+    
+    <!-- Boolean indicating whether the wifi chipset supports background scanning mechanism.
+         This mechanism allows the host to remain in suspend state and the dongle to actively
+         scan and wake the host when a configured SSID is detected by the dongle. This chipset
+         capability can provide power savings when wifi needs to be always kept on. -->
+    <bool name="config_wifi_background_scan_support">true</bool>
+    
+    <!-- Boolean indicating whether the wifi chipset has dual frequency band support -->
+    <bool translatable="false" name="config_wifi_dual_band_support">true</bool>
+
+    <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+    <bool name="config_wifi_batched_scan_supported">false</bool>
+ 
+    <bool name="config_wifi_enable_disconnection_debounce">true</bool>
+    <bool name="config_wifi_enable_wifi_firmware_debugging">true</bool>
+    <bool name="config_wifi_fast_bss_transition_enabled">false</bool>
+ 	
+</resources>

--- a/Huawei/kirin710/JKM/res/values/notch.xml
+++ b/Huawei/kirin710/JKM/res/values/notch.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2017, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- Height of the status bar -->
+    <dimen name="status_bar_height">5.439972mm</dimen>
+    <!-- Height of the status bar in portrait -->
+    <dimen name="status_bar_height_portrait">5.439972mm</dimen>
+    <!-- Height of the status bar in landscape -->
+    <dimen name="status_bar_height_landscape">5.439972mm</dimen>
+	<string translatable="false" name="config_mainBuiltInDisplayCutout">M145.908595,0.116 C145.907595,0.077 145.906596,0.039 145.905597,0 L-144.691732,0 C-144.692731,0.039 -144.693731,0.077 -144.69473,0.116 L-168,0.116 C-155.241064,0.116 -144.301978,8.866 -144.801662,23.329 L-144.708721,23.089 L-144.708721,30.71 C-141.803557,66.116 -120.452053,85 -90.5289654,85 L91.7428302,85 C123.278898,85 144.765317,61.616 145.922586,30.71 L145.922586,20.96 C147.11883,9.294 157.03956,0.116 169,0.116 L145.908595,0.116 Z</string>
+</resources>

--- a/Huawei/kirin710/JKM/res/xml/power_profile.xml
+++ b/Huawei/kirin710/JKM/res/xml/power_profile.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+**
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License")
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<device name="Android">
+  <!-- All values are in mA except as noted -->
+  <item name="none">0</item>
+  <item name="screen.on">135</item> <!-- min brite -->
+  <item name="bluetooth.active">86</item>
+  <item name="bluetooth.on">0.6</item>
+  <item name="bluetooth.at">0.6</item> <!-- TBD -->
+  <item name="screen.full">400</item> <!-- backlight 16 leds -->
+  <item name="wifi.on">0.6</item>
+  <item name="wifi.active">128</item>
+  <item name="wifi.scan">146</item>
+  <item name="dsp.audio">43</item>
+  <item name="dsp.video">176</item>
+  <item name="radio.active">190</item>
+  <item name="gps.on">70</item>
+  <item name="battery.capacity">4000</item> <!-- 3750mAh -->
+  <item name="radio.scanning">65</item> <!-- TBD -->
+  <!-- Current consumed by the radio at different signal strengths, when paging  -->
+  <array name="radio.on"> <!-- 1 entry per signal strength bin, TBD -->
+    <value>13.0</value>
+    <value>10.0</value>
+    <value>10.0</value>
+    <value>10.0</value>
+    <value>10.0</value>
+  </array>
+  <array name="cpu.clusters.cores">
+    <value>4</value> <!-- cluster 0 has cpu0, cpu1, cpu2, cpu3 -->
+    <value>4</value> <!-- cluster 1 has cpu4, cpu5, cpu6, cpu7 -->
+  </array>
+  <array name="cpu.speeds.cluster0">
+    <value>480000</value>  <!-- 480 MHz CPU speed -->
+    <value>960000</value>  <!-- 960 MHz CPU speed -->
+    <value>1152000</value> <!-- 1.1 GHz CPU speed -->
+    <value>1325000</value> <!-- 1.3 GHz CPU speed -->
+    <value>1440000</value> <!-- 1.4 GHz CPU speed -->
+    <value>1536000</value> <!-- 1.5 GHz CPU speed -->
+    <value>1709000</value> <!-- 1.7 GHz CPU speed -->
+  </array>
+  <!-- Power consumption at different speeds -->
+  <array name="cpu.active.cluster0">
+    <value>23</value>
+    <value>61</value>
+    <value>80</value>
+    <value>106</value>
+    <value>126</value>
+    <value>140</value>
+    <value>183</value>
+  </array>
+  <array name="cpu.speeds.cluster1">
+    <value>807000</value> <!-- 807 MHz CPU speed -->
+    <value>1037000</value><!-- 1.0 GHz CPU speed -->
+    <value>1268000</value><!-- 1.2 GHz CPU speed -->
+    <value>1460000</value><!-- 1.4 GHz CPU speed -->
+    <value>1671000</value><!-- 1.6 GHz CPU speed -->
+    <value>1824000</value><!-- 1.8 GHz CPU speed -->
+    <value>1997000</value><!-- 2.0 GHz CPU speed -->
+    <value>2189000</value><!-- 2.2 GHz CPU speed -->
+  </array>
+  <array name="cpu.active.cluster1">
+    <value>119</value>
+    <value>177</value>
+    <value>238</value>
+    <value>313</value>
+    <value>408</value>
+    <value>496</value>
+    <value>608</value>
+    <value>836</value>
+  </array>
+  <!-- Power consumption in suspend -->
+  <item name="cpu.idle">5</item>
+  <!-- Power consumption due to wake lock held -->
+  <item name="cpu.awake">35</item>
+</device>

--- a/overlay.mk
+++ b/overlay.mk
@@ -39,6 +39,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-huawei-DUK \
 	treble-overlay-huawei-EML \
 	treble-overlay-huawei-FIG \
+	treble-overlay-huawei-JKM \
 	treble-overlay-huawei-LLD \
 	treble-overlay-huawei-MAR \
 	treble-overlay-huawei-PIC \


### PR DESCRIPTION
Add the Overlay for Huawei JKM, the test model is JKM-LX2, it works well. Other models should work as long as they are JKM.This commit fixes many bugs.