### PR TITLE
Add overlay for Red Magic 6S Pro

### DIFF
--- a/Nubia/RedMagic6spro/Android.mk
+++ b/Nubia/RedMagic6spro/Android.mk
@@ -1,0 +1,8 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE_TAGS := optional
+LOCAL_PACKAGE_NAME := treble-overlay-nubia-redmagic6spro
+LOCAL_MODULE_PATH := $(TARGET_OUT_PRODUCT)/overlay
+LOCAL_IS_RUNTIME_RESOURCE_OVERLAY := true
+LOCAL_PRIVATE_PLATFORM_APIS := true
+include $(BUILD_PACKAGE)

--- a/Nubia/RedMagic6spro/AndroidManifest.xml
+++ b/Nubia/RedMagic6spro/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="me.phh.treble.overlay.nubia.redmagic6spro"
+        android:versionCode="1"
+        android:versionName="1.0">
+        <overlay android:targetPackage="android"
+                android:requiredSystemPropertyName="ro.vendor.build.fingerprint"
+                android:requiredSystemPropertyValue="+*ubia/NX669J*"
+		android:priority="280"
+		android:isStatic="true" />
+</manifest>

--- a/Nubia/RedMagic6spro/res/values/arrays.xml
+++ b/Nubia/RedMagic6spro/res/values/arrays.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="config_biometric_sensors">
+        <item>0:2:15</item>
+    </string-array>
+    <string-array name="config_defaultPinnerServiceFiles">
+        <item>/system/framework/arm64/boot-framework.oat</item>
+        <item>/system/framework/arm64/boot-QPerformance.oat</item>
+        <item>/system/framework/arm64/boot-UxPerformance.oat</item>
+        <item>/system/framework/framework.jar</item>
+        <item>/system/framework/oat/arm64/services.odex</item>
+        <item>/system/framework/services.jar</item>
+        <item>/apex/com.android.media/javalib/updatable-media.jar</item>
+        <item>/system/lib64/libsurfaceflinger.so</item>
+    </string-array>
+</resources>

--- a/Nubia/RedMagic6spro/res/values/bools.xml
+++ b/Nubia/RedMagic6spro/res/values/bools.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
-    <bool name="config_dozeAlwaysOnEnabled">false</bool>
     <bool name="config_showNavigationBar">true</bool>
     <bool name="config_useDevInputEventForAudioJack">true</bool>
 </resources>

--- a/Nubia/RedMagic6spro/res/values/bools.xml
+++ b/Nubia/RedMagic6spro/res/values/bools.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_dozeAlwaysOnDisplayAvailable">true</bool>
+    <bool name="config_dozeAlwaysOnEnabled">false</bool>
+    <bool name="config_showNavigationBar">true</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
+</resources>

--- a/Nubia/RedMagic6spro/res/values/config.xml
+++ b/Nubia/RedMagic6spro/res/values/config.xml
@@ -1,53 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <integer-array name="config_autoBrightnessLcdBacklightValues">
-    <item>10</item>
-    <item>20</item>
-    <item>40</item>
-    <item>70</item>
-    <item>110</item>
-    <item>160</item>
-    <item>200</item>
-    <item>255</item>
+    <item>4</item>
+    <item>9</item>
+    <item>27</item>
+    <item>48</item>
+    <item>61</item>
+    <item>69</item>
+    <item>117</item>
+    <item>170</item>
+    <item>223</item>
   </integer-array>
   <integer-array name="config_autoBrightnessLevels">
-    <item>10</item>
-    <item>30</item>
-    <item>60</item>
-    <item>100</item>
-    <item>150</item>
-    <item>210</item>
-    <item>255</item>
-  </integer-array>
-  <integer-array name="config_availableColorModes">
-    <item>0</item>
     <item>1</item>
-    <item>3</item>
-    <item>256</item>
-    <item>257</item>
-    <item>258</item>
-    <item>259</item>
-    <item>260</item>
-    <item>261</item>
-    <item>262</item>
-    <item>263</item>
-    <item>264</item>
-    <item>265</item>
-    <item>266</item>
-    <item>267</item>
-    <item>268</item>
-    <item>269</item>
-    <item>270</item>
+    <item>10</item>
+    <item>50</item>
+    <item>100</item>
+    <item>400</item>
+    <item>900</item>
+    <item>2000</item>
+    <item>5000</item>
   </integer-array>
-  <array name="config_minimumBrightnessCurveNits">
-    <item>0.0</item>
-    <item>50.0</item>
-    <item>90.0</item>
-  </array>
-  <array name="config_screenBrightnessNits" />
-
-  <array name="config_autoBrightnessDisplayValuesNits" />
+  <!-- Flag indicating whether the we should enable the automatic brightness in Settings.
+         Software implementation will be used if config_hardware_auto_brightness_available is not set -->
   <bool name="config_automatic_brightness_available">true</bool>
+
+  <!-- User activity timeout: Maximum screen dim duration as a percentage of screen off timeout.
+         This resource is similar to config_maximumScreenDimDuration but the maximum
+         screen dim duration is defined as a ratio of the overall screen off timeout
+         instead of as an absolute value in milliseconds.  This is useful for reducing
+         the dim duration when the screen off timeout is very short.
+         When computing the screen dim duration, the power manager uses the lesser
+         of the effective durations expressed by config_maximumScreenDimDuration and
+         config_maximumScreenDimRatio.
+         This value must be between 0% and 100%.  If the value is zero, the screen will not
+         dim before the device goes to sleep.
+    -->
+  <fraction name="config_maximumScreenDimRatio">29.999996%</fraction>
+
+  <!-- Stability requirements in milliseconds for accepting a new brightness level.  This is used
+         for debouncing the light sensor.  Different constants are used to debounce the light sensor
+         when adapting to brighter or darker environments.  This parameter controls how quickly
+         brightness changes occur in response to an observed change in light level that exceeds the
+         hysteresis threshold. -->
+  <integer name="config_autoBrightnessBrighteningLightDebounce">2000</integer>
+  <integer name="config_autoBrightnessDarkeningLightDebounce">4000</integer>
+
+  <!-- Default screen brightness setting.
+         Must be in the range specified by minimum and maximum. -->
+  <integer name="config_screenBrightnessSettingDefault">98</integer>
+
+  <!-- Screen brightness used to dim the screen when the user activity
+         timeout expires.  May be less than the minimum allowed brightness setting
+         that can be set by the user. -->
+  <integer name="config_screenBrightnessDim">8</integer>
+
+  <bool name="config_allowAutoBrightnessWhileDozing">false</bool>
+
+  <!-- Default screen brightness for VR setting. Target default value: 0x0BB for EVT1.1. -->
+  <!-- 8 bit brightness level of 6 corresponds to the 10 bit brightness level of 0x0B6,
+         8 bit brightness level of 7 corresponds to the 10 bit brightness level of 0x0C1 on EVT1.1. -->
+  <integer name="config_screenBrightnessForVrSettingDefault">7</integer>
+  <integer name="config_screenBrightnessForVrSettingMinimum">6</integer>
+  <integer name="config_screenBrightnessForVrSettingMaximum">7</integer>
+
+  <!-- Minimum screen brightness setting allowed by the power manager.
+         The user is forbidden from setting the brightness below this level. -->
+  <integer name="config_screenBrightnessSettingMinimum">1</integer>
+
+  <!-- Maximum screen brightness setting allowed by the power manager.
+         The user is forbidden from setting the brightness above this level. -->
+  <integer name="config_screenBrightnessSettingMaximum">255</integer>
   <bool name="config_setColorTransformAccelerated">true</bool>
   <bool name="config_supportAudioSourceUnprocessed">false</bool>
   <bool name="skip_restoring_network_selection">true</bool>
@@ -66,10 +89,6 @@
 
   <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">false</bool>
   <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
-  <fraction name="config_maximumScreenDimRatio">20.000004%</fraction>
-  <integer name="config_screenBrightnessSettingDefault">163</integer>
-  <integer name="config_screenBrightnessSettingMaximum">255</integer>
-  <integer name="config_screenBrightnessSettingMinimum">10</integer>
   <integer name="config_shutdownBatteryTemperature">680</integer>
 
   <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>

--- a/Nubia/RedMagic6spro/res/values/config.xml
+++ b/Nubia/RedMagic6spro/res/values/config.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <integer-array name="config_autoBrightnessLcdBacklightValues">
+    <item>10</item>
+    <item>20</item>
+    <item>40</item>
+    <item>70</item>
+    <item>110</item>
+    <item>160</item>
+    <item>200</item>
+    <item>255</item>
+  </integer-array>
+  <integer-array name="config_autoBrightnessLevels">
+    <item>10</item>
+    <item>30</item>
+    <item>60</item>
+    <item>100</item>
+    <item>150</item>
+    <item>210</item>
+    <item>255</item>
+  </integer-array>
+  <integer-array name="config_availableColorModes">
+    <item>0</item>
+    <item>1</item>
+    <item>3</item>
+    <item>256</item>
+    <item>257</item>
+    <item>258</item>
+    <item>259</item>
+    <item>260</item>
+    <item>261</item>
+    <item>262</item>
+    <item>263</item>
+    <item>264</item>
+    <item>265</item>
+    <item>266</item>
+    <item>267</item>
+    <item>268</item>
+    <item>269</item>
+    <item>270</item>
+  </integer-array>
+  <array name="config_minimumBrightnessCurveNits">
+    <item>0.0</item>
+    <item>50.0</item>
+    <item>90.0</item>
+  </array>
+  <array name="config_screenBrightnessNits" />
+
+  <array name="config_autoBrightnessDisplayValuesNits" />
+  <bool name="config_automatic_brightness_available">true</bool>
+  <bool name="config_setColorTransformAccelerated">true</bool>
+  <bool name="config_supportAudioSourceUnprocessed">false</bool>
+  <bool name="skip_restoring_network_selection">true</bool>
+  <bool name="config_bluetooth_le_peripheral_mode_supported">true</bool>
+  <bool name="config_carrier_volte_available">true</bool>
+  <bool name="config_device_volte_available">true</bool>
+  <bool name="config_device_vt_available">true</bool>
+  <bool name="config_device_wfc_ims_available">true</bool>
+  <bool name="config_hotswapCapable">true</bool>
+  <bool name="config_lidControlsSleep">false</bool>
+  <bool name="config_wifiDisplaySupportsProtectedBuffers">true</bool>
+  <bool name="config_wifi_background_scan_support">true</bool>
+  <bool name="config_wifi_batched_scan_supported">true</bool>
+  <bool name="config_wifi_dual_band_support">true</bool>
+  <bool name="config_displayBlanksAfterDoze">false</bool>
+
+  <bool name="config_powerDecoupleAutoSuspendModeFromDisplay">false</bool>
+  <fraction name="config_autoBrightnessAdjustmentMaxGamma">300.0%</fraction>
+  <fraction name="config_maximumScreenDimRatio">20.000004%</fraction>
+  <integer name="config_screenBrightnessSettingDefault">163</integer>
+  <integer name="config_screenBrightnessSettingMaximum">255</integer>
+  <integer name="config_screenBrightnessSettingMinimum">10</integer>
+  <integer name="config_shutdownBatteryTemperature">680</integer>
+
+  <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+  <bool name="config_dozeAfterScreenOff">true</bool>
+</resources>

--- a/Nubia/RedMagic6spro/res/values/dimens.xml
+++ b/Nubia/RedMagic6spro/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="rounded_corner_content_padding">0.0dip</dimen>
+    <dimen name="rounded_corner_radius">20.0dip</dimen>
+    <dimen name="status_bar_height_portrait">37.0dip</dimen>
+</resources>

--- a/Nubia/RedMagic6spro/res/values/dimens.xml
+++ b/Nubia/RedMagic6spro/res/values/dimens.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="rounded_corner_content_padding">0.0dip</dimen>
     <dimen name="rounded_corner_radius">20.0dip</dimen>
     <dimen name="status_bar_height_portrait">37.0dip</dimen>
 </resources>

--- a/Nubia/RedMagic6spro/res/values/integers.xml
+++ b/Nubia/RedMagic6spro/res/values/integers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="config_bluetooth_idle_cur_ma">6</integer>
+    <integer name="config_bluetooth_operating_voltage_mv">3700</integer>
+    <integer name="config_bluetooth_rx_cur_ma">28</integer>
+    <integer name="config_bluetooth_tx_cur_ma">36</integer>
+</resources>

--- a/Nubia/RedMagic6spro/res/values/strings.xml
+++ b/Nubia/RedMagic6spro/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="config_qualified_networks_service_package">vendor.qti.iwlan</string>
+    <string name="config_wlan_data_service_package">vendor.qti.iwlan</string>
+    <string name="config_wlan_network_service_package">vendor.qti.iwlan</string>
+</resources>

--- a/Nubia/RedMagic6spro/res/values/strings.xml
+++ b/Nubia/RedMagic6spro/res/values/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="config_qualified_networks_service_package">vendor.qti.iwlan</string>
-    <string name="config_wlan_data_service_package">vendor.qti.iwlan</string>
-    <string name="config_wlan_network_service_package">vendor.qti.iwlan</string>
-</resources>

--- a/Nubia/RedMagic6spro/res/xml/power_profile.xml
+++ b/Nubia/RedMagic6spro/res/xml/power_profile.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device name="Android">
+    <item name="none">0</item>
+    <item name="screen.on">176</item>
+    <item name="screen.full">460</item>
+    <array name="cpu.clusters.cores">
+        <value>4</value>
+        <value>3</value>
+        <value>1</value>
+    </array>
+    <array name="cpu.core_speeds.cluster0">
+        <value>300000</value>
+        <value>403200</value>
+        <value>499200</value>
+        <value>595200</value>
+        <value>691200</value>
+        <value>806400</value>
+        <value>902400</value>
+        <value>998400</value>
+        <value>1094400</value>
+        <value>1209600</value>
+        <value>1305600</value>
+        <value>1401600</value>
+        <value>1497600</value>
+        <value>1612800</value>
+        <value>1708800</value>
+        <value>1804800</value>
+    </array>
+    <array name="cpu.core_power.cluster0">
+        <value>5</value>
+        <value>7</value>
+        <value>8</value>
+        <value>9</value>
+        <value>10</value>
+        <value>14</value>
+        <value>16</value>
+        <value>18</value>
+        <value>21</value>
+        <value>23</value>
+        <value>24</value>
+        <value>27</value>
+        <value>29</value>
+        <value>31</value>
+        <value>32</value>
+        <value>35</value>
+    </array>
+    <array name="cpu.core_speeds.cluster1">
+        <value>710400</value>
+        <value>844800</value>
+        <value>960000</value>
+        <value>1075200</value>
+        <value>1209600</value>
+        <value>1324800</value>
+        <value>1440000</value>
+        <value>1555200</value>
+        <value>1670400</value>
+        <value>1766400</value>
+        <value>1881600</value>
+        <value>1996800</value>
+        <value>2112000</value>
+        <value>2227200</value>
+        <value>2342400</value>
+        <value>2419200</value>
+    </array>
+    <array name="cpu.core_power.cluster1">
+        <value>31</value>
+        <value>39</value>
+        <value>47</value>
+        <value>59</value>
+        <value>70</value>
+        <value>81</value>
+        <value>94</value>
+        <value>103</value>
+        <value>122</value>
+        <value>137</value>
+        <value>160</value>
+        <value>182</value>
+        <value>192</value>
+        <value>220</value>
+        <value>270</value>
+        <value>317</value>
+    </array>
+    <array name="cpu.core_speeds.cluster2">
+        <value>844800</value>
+        <value>960000</value>
+        <value>1075200</value>
+        <value>1190400</value>
+        <value>1305600</value>
+        <value>1420800</value>
+        <value>1555200</value>
+        <value>1670400</value>
+        <value>1785600</value>
+        <value>1900800</value>
+        <value>2035200</value>
+        <value>2150400</value>
+        <value>2265600</value>
+        <value>2380800</value>
+        <value>2496000</value>
+        <value>2611200</value>
+        <value>2726400</value>
+        <value>2841600</value>
+    </array>
+    <array name="cpu.core_power.cluster2">
+        <value>49</value>
+        <value>59</value>
+        <value>69</value>
+        <value>82</value>
+        <value>96</value>
+        <value>113</value>
+        <value>133</value>
+        <value>157</value>
+        <value>172</value>
+        <value>182</value>
+        <value>210</value>
+        <value>247</value>
+        <value>289</value>
+        <value>332</value>
+        <value>374</value>
+        <value>471</value>
+        <value>516</value>
+        <value>583</value>
+    </array>
+    <item name="cpu.active">7.7</item>
+    <item name="cpu.idle">0.1</item>
+    <item name="cpu.suspend">0</item>
+    <item name="battery.capacity">4500</item>
+    <item name="wifi.on">0.1</item>
+    <item name="wifi.active">160</item>
+    <item name="wifi.scan">1.2</item>
+    <item name="dsp.audio">24</item>
+    <item name="dsp.video">66</item>
+    <item name="camera.flashlight">600</item>
+    <item name="camera.avg">368</item>
+    <item name="gps.on">13.7</item>
+    <item name="radio.active">160</item>
+    <item name="radio.scanning">5.5</item>
+    <array name="radio.on">
+        <value>86</value>
+        <value>8</value>
+    </array>
+    <item name="modem.controller.idle">6</item>
+    <item name="modem.controller.rx">180</item>
+    <item name="modem.controller.tx">186</item>
+    <item name="modem.controller.voltage">3700</item>
+    <array name="memory.bandwidths">
+        <value>17</value>
+    </array>
+    <item name="wifi.controller.idle">1</item>
+    <item name="wifi.controller.rx">176</item>
+    <item name="wifi.controller.tx">200</item>
+    <array name="wifi.controller.tx_levels">1 </array>
+    <item name="wifi.controller.voltage">3700</item>
+    <array name="wifi.batchedscan">
+        <value>.0001</value>
+        <value>.001</value>
+        <value>.01</value>
+        <value>.1</value>
+        <value>1</value>
+    </array>
+    <item name="bluetooth.active">130</item>
+    <item name="bluetooth.on">0.7</item>
+    <item name="bluetooth.controller.voltage">3700</item>
+</device>

--- a/Samsung/o1s/res/values/config.xml
+++ b/Samsung/o1s/res/values/config.xml
@@ -19,7 +19,7 @@
         <item>30</item>
     </integer-array>
 	    <integer name="config_autoBrightnessBrighteningLightDebounce">3000</integer>
-        <integer name="config_screenBrightnessSettingDefault">128</integer>
+        <integer name="config_screenBrightnessSettingDefault">0</integer>
         <integer name="config_screenBrightnessSettingMaximum">255</integer>
         <integer name="config_screenBrightnessSettingMinimum">0</integer>
 	    <integer name="config_screenBrightnessDoze">17</integer>

--- a/overlay.mk
+++ b/overlay.mk
@@ -6,7 +6,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-NightMode \
 	treble-overlay-SystemUI-FalseLocks \
 	treble-overlay-Telephony-LTE \
-	treble-overlay-alldocube-xneo \
 	treble-overlay-asus-rogphone \
 	treble-overlay-asus-zenfone5 \
 	treble-overlay-asus-zenfone5-10 \
@@ -21,8 +20,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-caf-ims \
 	treble-overlay-devinputjack \
 	treble-overlay-duoqin-qin2pro \
-	treble-overlay-duoqin-qin3ultra \
-	treble-overlay-duoqin-qin3ultra-systemui \
 	treble-overlay-duoqin-qinf21pro \
 	treble-overlay-essential-ph_1 \
 	treble-overlay-fairphone-fp3 \
@@ -42,7 +39,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-huawei-DUK \
 	treble-overlay-huawei-EML \
 	treble-overlay-huawei-FIG \
-	treble-overlay-huawei-JKM \
 	treble-overlay-huawei-LLD \
 	treble-overlay-huawei-MAR \
 	treble-overlay-huawei-PIC \
@@ -74,7 +70,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-lg-phoenix_lao_com-phoenix_sprout \
 	treble-overlay-lg-v40 \
 	treble-overlay-lg-velvet \
-	treble-overlay-lge-lm_v500n \
 	treble-overlay-lge-mfh505glm \
 	treble-overlay-lge-mfh505glm-systemui \
 	treble-overlay-lge-timelm \
@@ -86,7 +81,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-misc-aod-systemui \
 	treble-overlay-misc-dt2w \
 	treble-overlay-misc-minimal-brightness \
-	treble-overlay-misc-spen-pointer \
 	treble-overlay-moto-e5 \
 	treble-overlay-moto-e5plus \
 	treble-overlay-moto-e6plus \
@@ -112,15 +106,12 @@ PRODUCT_PACKAGES += \
 	treble-overlay-moto-razr \
 	treble-overlay-moto-rhodep \
 	treble-overlay-moto-rhodep-systemui \
-	treble-overlay-moto-tesla \
-	treble-overlay-moto-tesla-systemui \
 	treble-overlay-moto-tundra \
 	treble-overlay-moto-tundra-systemui \
 	treble-overlay-mtk-ims \
 	treble-overlay-nokia-b2n-7plus \
 	treble-overlay-nokia-ctl-7-1 \
 	treble-overlay-nokia-drg-6.1plus-x6 \
-	treble-overlay-nokia-nokia_3_2 \
 	treble-overlay-nokia-nokia_4_2 \
 	treble-overlay-nokia-nokia_7_2 \
 	treble-overlay-nokia-nokia_7_2-systemui \
@@ -131,10 +122,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-nubia-redmagic3s \
 	treble-overlay-nubia-redmagic6spro \
 	treble-overlay-nubia-z18mini \
-	treble-overlay-oneplus-ace2 \
-	treble-overlay-oneplus-ace2-systemui \
-	treble-overlay-oneplus-ace2v \
-	treble-overlay-oneplus-ace2v-systemui \
 	treble-overlay-oneplus-acepro \
 	treble-overlay-oneplus-acepro-systemui \
 	treble-overlay-oneplus-n10 \
@@ -161,8 +148,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-onn-mid7019 \
 	treble-overlay-oppo-a54 \
 	treble-overlay-oppo-a54-systemui \
-	treble-overlay-oppo-findx \
-	treble-overlay-oppo-findx-systemui \
 	treble-overlay-oppo-findx3pro \
 	treble-overlay-oppo-findx3pro-systemui \
 	treble-overlay-oppo-reno6-5g \
@@ -172,19 +157,12 @@ PRODUCT_PACKAGES += \
 	treble-overlay-oukitel-c18pro \
 	treble-overlay-oukitel-wp8pro \
 	treble-overlay-razer-cheryl \
-	treble-overlay-realme-10pro \
-	treble-overlay-realme-10pro-systemui \
 	treble-overlay-realme-6 \
 	treble-overlay-realme-6i \
 	treble-overlay-realme-8-5g \
 	treble-overlay-realme-8-5g-systemui \
-	treble-overlay-realme-8pro \
-	treble-overlay-realme-9i \
-	treble-overlay-realme-9i-systemui \
 	treble-overlay-realme-c2 \
 	treble-overlay-realme-c3 \
-	treble-overlay-realme-gt2master \
-	treble-overlay-realme-gt2master-systemui \
 	treble-overlay-realme-gt2pro \
 	treble-overlay-realme-gt2pro-systemui \
 	treble-overlay-realme-gtmaster \
@@ -204,10 +182,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-S20-systemui \
 	treble-overlay-samsung-S20fe \
 	treble-overlay-samsung-S20fe-systemui \
-	treble-overlay-samsung-a02q \
-	treble-overlay-samsung-a02q-systemui \
-	treble-overlay-samsung-a03 \
-	treble-overlay-samsung-a10s \
 	treble-overlay-samsung-a20 \
 	treble-overlay-samsung-a20s \
 	treble-overlay-samsung-a20s-systemui \
@@ -221,7 +195,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-a33 \
 	treble-overlay-samsung-a33-systemui \
 	treble-overlay-samsung-a40 \
-	treble-overlay-samsung-a40-systemui \
 	treble-overlay-samsung-a50 \
 	treble-overlay-samsung-a51 \
 	treble-overlay-samsung-a51-systemui \
@@ -288,7 +261,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-teclast-p20hd \
 	treble-overlay-teclast-t30 \
 	treble-overlay-tecno-camon11 \
-	treble-overlay-tecno-pova4pro \
 	treble-overlay-tecno-spark5 \
 	treble-overlay-tecno-spark6 \
 	treble-overlay-telephony-caf-ims \
@@ -305,7 +277,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-umidigi-A5pro \
 	treble-overlay-umidigi-power \
 	treble-overlay-unihertz-jelly2 \
-	treble-overlay-unihertz-luna \
 	treble-overlay-unihertz-titanpocketeea \
 	treble-overlay-vivo-y20 \
 	treble-overlay-vivo-y20-systemui \
@@ -318,10 +289,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-civi-systemui \
 	treble-overlay-xiaomi-mi11lite5g \
 	treble-overlay-xiaomi-mi11tpro \
-	treble-overlay-xiaomi-mi12lite \
-	treble-overlay-xiaomi-mi12lite-systemui \
-	treble-overlay-xiaomi-mi13 \
-	treble-overlay-xiaomi-mi13-systemui \
 	treble-overlay-xiaomi-mi6x \
 	treble-overlay-xiaomi-mi8 \
 	treble-overlay-xiaomi-mi8ee \
@@ -342,13 +309,10 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-pocof1 \
 	treble-overlay-xiaomi-pocof4 \
 	treble-overlay-xiaomi-pocof4-systemui \
-	treble-overlay-xiaomi-pocof5 \
-	treble-overlay-xiaomi-pocof5-systemui \
 	treble-overlay-xiaomi-pocom3pro5g \
 	treble-overlay-xiaomi-pocom4pro5g \
 	treble-overlay-xiaomi-pocom4pro5g-systemui \
 	treble-overlay-xiaomi-pocom5 \
-	treble-overlay-xiaomi-pocom5-systemui \
 	treble-overlay-xiaomi-pocox3gt \
 	treble-overlay-xiaomi-redmi10x5g \
 	treble-overlay-xiaomi-redmi10x5g-systemui \
@@ -380,7 +344,6 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redminote6pro \
 	treble-overlay-xiaomi-redminote6pro-systemui \
 	treble-overlay-xiaomi-redminote7 \
-	treble-overlay-xiaomi-redminote8 \
 	treble-overlay-xiaomi-redminote8pro \
 	treble-overlay-xiaomi-redminote9pro \
 	treble-overlay-xiaomi-redminote9promax \

--- a/overlay.mk
+++ b/overlay.mk
@@ -6,6 +6,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-NightMode \
 	treble-overlay-SystemUI-FalseLocks \
 	treble-overlay-Telephony-LTE \
+	treble-overlay-alldocube-xneo \
 	treble-overlay-asus-rogphone \
 	treble-overlay-asus-zenfone5 \
 	treble-overlay-asus-zenfone5-10 \
@@ -20,6 +21,8 @@ PRODUCT_PACKAGES += \
 	treble-overlay-caf-ims \
 	treble-overlay-devinputjack \
 	treble-overlay-duoqin-qin2pro \
+	treble-overlay-duoqin-qin3ultra \
+	treble-overlay-duoqin-qin3ultra-systemui \
 	treble-overlay-duoqin-qinf21pro \
 	treble-overlay-essential-ph_1 \
 	treble-overlay-fairphone-fp3 \
@@ -39,6 +42,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-huawei-DUK \
 	treble-overlay-huawei-EML \
 	treble-overlay-huawei-FIG \
+	treble-overlay-huawei-JKM \
 	treble-overlay-huawei-LLD \
 	treble-overlay-huawei-MAR \
 	treble-overlay-huawei-PIC \
@@ -70,6 +74,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-lg-phoenix_lao_com-phoenix_sprout \
 	treble-overlay-lg-v40 \
 	treble-overlay-lg-velvet \
+	treble-overlay-lge-lm_v500n \
 	treble-overlay-lge-mfh505glm \
 	treble-overlay-lge-mfh505glm-systemui \
 	treble-overlay-lge-timelm \
@@ -81,6 +86,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-misc-aod-systemui \
 	treble-overlay-misc-dt2w \
 	treble-overlay-misc-minimal-brightness \
+	treble-overlay-misc-spen-pointer \
 	treble-overlay-moto-e5 \
 	treble-overlay-moto-e5plus \
 	treble-overlay-moto-e6plus \
@@ -106,12 +112,15 @@ PRODUCT_PACKAGES += \
 	treble-overlay-moto-razr \
 	treble-overlay-moto-rhodep \
 	treble-overlay-moto-rhodep-systemui \
+	treble-overlay-moto-tesla \
+	treble-overlay-moto-tesla-systemui \
 	treble-overlay-moto-tundra \
 	treble-overlay-moto-tundra-systemui \
 	treble-overlay-mtk-ims \
 	treble-overlay-nokia-b2n-7plus \
 	treble-overlay-nokia-ctl-7-1 \
 	treble-overlay-nokia-drg-6.1plus-x6 \
+	treble-overlay-nokia-nokia_3_2 \
 	treble-overlay-nokia-nokia_4_2 \
 	treble-overlay-nokia-nokia_7_2 \
 	treble-overlay-nokia-nokia_7_2-systemui \
@@ -120,7 +129,12 @@ PRODUCT_PACKAGES += \
 	treble-overlay-nokia-pnx-8.1-x7 \
 	treble-overlay-nokia-pnx-8.1-x7-systemui \
 	treble-overlay-nubia-redmagic3s \
+	treble-overlay-nubia-redmagic6spro \
 	treble-overlay-nubia-z18mini \
+	treble-overlay-oneplus-ace2 \
+	treble-overlay-oneplus-ace2-systemui \
+	treble-overlay-oneplus-ace2v \
+	treble-overlay-oneplus-ace2v-systemui \
 	treble-overlay-oneplus-acepro \
 	treble-overlay-oneplus-acepro-systemui \
 	treble-overlay-oneplus-n10 \
@@ -147,6 +161,8 @@ PRODUCT_PACKAGES += \
 	treble-overlay-onn-mid7019 \
 	treble-overlay-oppo-a54 \
 	treble-overlay-oppo-a54-systemui \
+	treble-overlay-oppo-findx \
+	treble-overlay-oppo-findx-systemui \
 	treble-overlay-oppo-findx3pro \
 	treble-overlay-oppo-findx3pro-systemui \
 	treble-overlay-oppo-reno6-5g \
@@ -156,12 +172,19 @@ PRODUCT_PACKAGES += \
 	treble-overlay-oukitel-c18pro \
 	treble-overlay-oukitel-wp8pro \
 	treble-overlay-razer-cheryl \
+	treble-overlay-realme-10pro \
+	treble-overlay-realme-10pro-systemui \
 	treble-overlay-realme-6 \
 	treble-overlay-realme-6i \
 	treble-overlay-realme-8-5g \
 	treble-overlay-realme-8-5g-systemui \
+	treble-overlay-realme-8pro \
+	treble-overlay-realme-9i \
+	treble-overlay-realme-9i-systemui \
 	treble-overlay-realme-c2 \
 	treble-overlay-realme-c3 \
+	treble-overlay-realme-gt2master \
+	treble-overlay-realme-gt2master-systemui \
 	treble-overlay-realme-gt2pro \
 	treble-overlay-realme-gt2pro-systemui \
 	treble-overlay-realme-gtmaster \
@@ -181,6 +204,10 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-S20-systemui \
 	treble-overlay-samsung-S20fe \
 	treble-overlay-samsung-S20fe-systemui \
+	treble-overlay-samsung-a02q \
+	treble-overlay-samsung-a02q-systemui \
+	treble-overlay-samsung-a03 \
+	treble-overlay-samsung-a10s \
 	treble-overlay-samsung-a20 \
 	treble-overlay-samsung-a20s \
 	treble-overlay-samsung-a20s-systemui \
@@ -194,6 +221,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-samsung-a33 \
 	treble-overlay-samsung-a33-systemui \
 	treble-overlay-samsung-a40 \
+	treble-overlay-samsung-a40-systemui \
 	treble-overlay-samsung-a50 \
 	treble-overlay-samsung-a51 \
 	treble-overlay-samsung-a51-systemui \
@@ -260,6 +288,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-teclast-p20hd \
 	treble-overlay-teclast-t30 \
 	treble-overlay-tecno-camon11 \
+	treble-overlay-tecno-pova4pro \
 	treble-overlay-tecno-spark5 \
 	treble-overlay-tecno-spark6 \
 	treble-overlay-telephony-caf-ims \
@@ -276,6 +305,7 @@ PRODUCT_PACKAGES += \
 	treble-overlay-umidigi-A5pro \
 	treble-overlay-umidigi-power \
 	treble-overlay-unihertz-jelly2 \
+	treble-overlay-unihertz-luna \
 	treble-overlay-unihertz-titanpocketeea \
 	treble-overlay-vivo-y20 \
 	treble-overlay-vivo-y20-systemui \
@@ -288,6 +318,10 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-civi-systemui \
 	treble-overlay-xiaomi-mi11lite5g \
 	treble-overlay-xiaomi-mi11tpro \
+	treble-overlay-xiaomi-mi12lite \
+	treble-overlay-xiaomi-mi12lite-systemui \
+	treble-overlay-xiaomi-mi13 \
+	treble-overlay-xiaomi-mi13-systemui \
 	treble-overlay-xiaomi-mi6x \
 	treble-overlay-xiaomi-mi8 \
 	treble-overlay-xiaomi-mi8ee \
@@ -308,10 +342,13 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-pocof1 \
 	treble-overlay-xiaomi-pocof4 \
 	treble-overlay-xiaomi-pocof4-systemui \
+	treble-overlay-xiaomi-pocof5 \
+	treble-overlay-xiaomi-pocof5-systemui \
 	treble-overlay-xiaomi-pocom3pro5g \
 	treble-overlay-xiaomi-pocom4pro5g \
 	treble-overlay-xiaomi-pocom4pro5g-systemui \
 	treble-overlay-xiaomi-pocom5 \
+	treble-overlay-xiaomi-pocom5-systemui \
 	treble-overlay-xiaomi-pocox3gt \
 	treble-overlay-xiaomi-redmi10x5g \
 	treble-overlay-xiaomi-redmi10x5g-systemui \
@@ -343,11 +380,11 @@ PRODUCT_PACKAGES += \
 	treble-overlay-xiaomi-redminote6pro \
 	treble-overlay-xiaomi-redminote6pro-systemui \
 	treble-overlay-xiaomi-redminote7 \
+	treble-overlay-xiaomi-redminote8 \
 	treble-overlay-xiaomi-redminote8pro \
 	treble-overlay-xiaomi-redminote9pro \
 	treble-overlay-xiaomi-redminote9promax \
 	treble-overlay-xiaomi-redminote9s \
 	treble-overlay-xiaomi-redminote9t \
 	treble-overlay-xiaomi-redmis2 \
-
 


### PR DESCRIPTION
Fixed auto brightness.
I tested it on my own phone (6s Pro), It may work with the 6s model as well because they use the same fingerprint. The configurations are obtained from Nubia's official Android 12 ROM.