### PR TITLE
Workflows: Update to v4 of the artifact actions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -28,7 +28,7 @@ jobs:
         bash build.sh
 
     - name: Upload APK
-      uses: actions/upload-artifact@v3.0.0
+      uses: actions/upload-artifact@v4
       with:
         path: build/*.apk
         name: Overlays


### PR DESCRIPTION
Deprecation notice for v3 of the artifact actions starting November 30,2024.
Please do refer [this](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) for more information regarding the same.